### PR TITLE
Make message header required in`ErrorFrame`

### DIFF
--- a/stompman/frames.py
+++ b/stompman/frames.py
@@ -188,8 +188,7 @@ class MessageFrame:
 
 
 ErrorHeaders = TypedDict(
-    "ErrorHeaders",
-    {"message": NotRequired[str], "content-length": NotRequired[str], "content-type": NotRequired[str]},
+    "ErrorHeaders", {"message": str, "content-length": NotRequired[str], "content-type": NotRequired[str]}
 )
 
 


### PR DESCRIPTION
From [spec](https://stomp.github.io/stomp-specification-1.2.html#ERROR):

> The ERROR frame SHOULD contain a message header with a short description of the error, and the body MAY contain more detailed information (or MAY be empty).