### PR TITLE
Fix graceful shutdown when using uvloop

### DIFF
--- a/stompman/client.py
+++ b/stompman/client.py
@@ -269,7 +269,7 @@ class Client:
 class MessageEvent:
     body: bytes = field(init=False)
     _frame: MessageFrame
-    _client: "Client" = field(repr=False)
+    _client: Client = field(repr=False)
 
     def __post_init__(self) -> None:
         self.body = self._frame.body
@@ -314,7 +314,7 @@ class ErrorEvent:
     body: bytes = field(init=False)
     """Long description of the error."""
     _frame: ErrorFrame
-    _client: "Client" = field(repr=False)
+    _client: Client = field(repr=False)
 
     def __post_init__(self) -> None:
         self.message_header = self._frame.headers["message"]
@@ -324,7 +324,7 @@ class ErrorEvent:
 @dataclass
 class HeartbeatEvent:
     _frame: HeartbeatFrame
-    _client: "Client" = field(repr=False)
+    _client: Client = field(repr=False)
 
 
 AnyListeningEvent = MessageEvent | ErrorEvent | HeartbeatEvent

--- a/stompman/connection.py
+++ b/stompman/connection.py
@@ -59,7 +59,8 @@ class Connection(AbstractConnection):
         return self.writer.write(NEWLINE)
 
     async def write_frame(self, frame: AnyClientFrame) -> None:
-        self.writer.write(dump_frame(frame))
+        with _reraise_connection_lost(RuntimeError):
+            self.writer.write(dump_frame(frame))
         with _reraise_connection_lost(ConnectionError):
             await self.writer.drain()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ import pytest
         pytest.param(("asyncio", {"use_uvloop": True}), id="asyncio+uvloop"),
         pytest.param(("asyncio", {"use_uvloop": False}), id="asyncio"),
     ],
-    autouse=True,
 )
 def anyio_backend(request: pytest.FixtureRequest) -> object:
     return request.param

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -2,11 +2,18 @@ import asyncio
 import os
 from uuid import uuid4
 
+import pytest
+
 import stompman
+from stompman.errors import ConnectionLostError
 
 
-async def test_integration() -> None:
-    server = stompman.ConnectionParameters(host=os.environ["ARTEMIS_HOST"], port=61616, login="admin", passcode="admin")
+@pytest.fixture()
+def server() -> stompman.ConnectionParameters:
+    return stompman.ConnectionParameters(host=os.environ["ARTEMIS_HOST"], port=61616, login="admin", passcode="admin")
+
+
+async def test_ok(server: stompman.ConnectionParameters) -> None:
     destination = "DLQ"
     messages = [str(uuid4()).encode() for _ in range(10000)]
 
@@ -38,3 +45,9 @@ async def test_integration() -> None:
     ):
         task_group.create_task(consume())
         task_group.create_task(produce())
+
+
+async def test_raises_connection_lost_error(server: stompman.ConnectionParameters) -> None:
+    with pytest.raises(ConnectionLostError):
+        async with stompman.Client(servers=[server], read_timeout=10, connection_confirmation_timeout=10) as consumer:
+            await consumer._connection.close()

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -7,6 +7,8 @@ import pytest
 import stompman
 from stompman.errors import ConnectionLostError
 
+pytestmark = pytest.mark.anyio
+
 
 @pytest.fixture()
 def server() -> stompman.ConnectionParameters:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,6 +34,8 @@ from stompman import (
 )
 from stompman.client import ConnectionParameters, ErrorEvent, HeartbeatEvent, MessageEvent
 
+pytestmark = pytest.mark.anyio
+
 
 @dataclass
 class BaseMockConnection(AbstractConnection):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -7,18 +7,23 @@ from unittest import mock
 
 import pytest
 
-from stompman import (
-    AnyServerFrame,
-    ConnectedFrame,
-    Connection,
-    ConnectionLostError,
-    HeartbeatFrame,
-)
+from stompman import AnyServerFrame, ConnectedFrame, Connection, ConnectionLostError, HeartbeatFrame
 from stompman.frames import BeginFrame, CommitFrame
 
 
 async def make_connection() -> Connection | None:
     return await Connection.connect(host="localhost", port=12345, timeout=2)
+
+
+async def make_mocked_connection(
+    monkeypatch: pytest.MonkeyPatch,
+    reader: Any,  # noqa: ANN401
+    writer: Any,  # noqa: ANN401
+) -> Connection:
+    monkeypatch.setattr("asyncio.open_connection", mock.AsyncMock(return_value=(reader, writer)))
+    connection = await make_connection()
+    assert connection
+    return connection
 
 
 def mock_wait_for(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -57,18 +62,20 @@ async def test_connection_lifespan(monkeypatch: pytest.MonkeyPatch) -> None:
         b"som",
         b"e server\nversion:1.2\n\n\x00",
     ]
+    expected_frames = [
+        HeartbeatFrame(),
+        HeartbeatFrame(),
+        HeartbeatFrame(),
+        ConnectedFrame(headers={"heart-beat": "0,0", "version": "1.2", "server": "some server"}),
+    ]
+    max_chunk_size = 1024
 
     class MockReader:
         read = mock.AsyncMock(side_effect=read_bytes)
 
-    monkeypatch.setattr("asyncio.open_connection", mock.AsyncMock(return_value=(MockReader(), MockWriter())))
-    connection = await make_connection()
-    assert connection
-
+    connection = await make_mocked_connection(monkeypatch, MockReader(), MockWriter())
     connection.write_heartbeat()
     await connection.write_frame(CommitFrame(headers={"transaction": "transaction"}))
-
-    max_chunk_size = 1024
 
     async def take_frames(count: int) -> list[AnyServerFrame]:
         frames = []
@@ -79,12 +86,6 @@ async def test_connection_lifespan(monkeypatch: pytest.MonkeyPatch) -> None:
 
         return frames
 
-    expected_frames = [
-        HeartbeatFrame(),
-        HeartbeatFrame(),
-        HeartbeatFrame(),
-        ConnectedFrame(headers={"heart-beat": "0,0", "version": "1.2", "server": "some server"}),
-    ]
     assert await take_frames(len(expected_frames)) == expected_frames
     await connection.close()
 
@@ -100,10 +101,7 @@ async def test_connection_close_connection_error(monkeypatch: pytest.MonkeyPatch
         close = mock.Mock()
         wait_closed = mock.AsyncMock(side_effect=ConnectionError)
 
-    monkeypatch.setattr("asyncio.open_connection", mock.AsyncMock(return_value=(mock.Mock(), MockWriter())))
-    connection = await make_connection()
-    assert connection
-
+    connection = await make_mocked_connection(monkeypatch, mock.Mock(), MockWriter())
     with pytest.raises(ConnectionLostError):
         await connection.close()
 
@@ -113,10 +111,7 @@ async def test_connection_write_frame_connection_error(monkeypatch: pytest.Monke
         write = mock.Mock()
         drain = mock.AsyncMock(side_effect=ConnectionError)
 
-    monkeypatch.setattr("asyncio.open_connection", mock.AsyncMock(return_value=(mock.Mock(), MockWriter())))
-    connection = await make_connection()
-    assert connection
-
+    connection = await make_mocked_connection(monkeypatch, mock.Mock(), MockWriter())
     with pytest.raises(ConnectionLostError):
         await connection.write_frame(BeginFrame(headers={"transaction": ""}))
 
@@ -126,10 +121,7 @@ async def test_connection_write_frame_runtime_error(monkeypatch: pytest.MonkeyPa
         write = mock.Mock(side_effect=RuntimeError)
         drain = mock.AsyncMock()
 
-    monkeypatch.setattr("asyncio.open_connection", mock.AsyncMock(return_value=(mock.Mock(), MockWriter())))
-    connection = await make_connection()
-    assert connection
-
+    connection = await make_mocked_connection(monkeypatch, mock.Mock(), MockWriter())
     with pytest.raises(ConnectionLostError):
         await connection.write_frame(BeginFrame(headers={"transaction": ""}))
 
@@ -144,29 +136,19 @@ async def test_connection_connect_connection_error(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr("asyncio.open_connection", mock.AsyncMock(side_effect=exception))
     assert not await make_connection()
 
-# TODO: Add mock_open_connection def
-async def test_read_frames_timeout_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "asyncio.open_connection",
-        mock.AsyncMock(return_value=(mock.AsyncMock(read=partial(asyncio.sleep, 5)), mock.AsyncMock())),
-    )
-    connection = await make_connection()
-    assert connection
 
+async def test_read_frames_timeout_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    connection = await make_mocked_connection(
+        monkeypatch, mock.AsyncMock(read=partial(asyncio.sleep, 5)), mock.AsyncMock()
+    )
     mock_wait_for(monkeypatch)
     with pytest.raises(ConnectionLostError):
         [frame async for frame in connection.read_frames(1024, 1)]
 
 
 async def test_read_frames_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "asyncio.open_connection",
-        mock.AsyncMock(
-            return_value=(mock.AsyncMock(read=mock.AsyncMock(side_effect=BrokenPipeError)), mock.AsyncMock())
-        ),
+    connection = await make_mocked_connection(
+        monkeypatch, mock.AsyncMock(read=mock.AsyncMock(side_effect=BrokenPipeError)), mock.AsyncMock()
     )
-    connection = await make_connection()
-    assert connection
-
     with pytest.raises(ConnectionLostError):
         [frame async for frame in connection.read_frames(1024, 1)]

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -10,6 +10,8 @@ import pytest
 from stompman import AnyServerFrame, ConnectedFrame, Connection, ConnectionLostError, HeartbeatFrame
 from stompman.frames import BeginFrame, CommitFrame
 
+pytestmark = pytest.mark.anyio
+
 
 async def make_connection() -> Connection | None:
     return await Connection.connect(host="localhost", port=12345, timeout=2)


### PR DESCRIPTION
It failed when was writing frames in `Client.__aexit__()`