### PR TITLE
Adding msg process context manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .venv
 dist
 uv.lock
+.idea

--- a/stompman/client.py
+++ b/stompman/client.py
@@ -32,6 +32,7 @@ from stompman.frames import (
     SubscribeFrame,
     UnsubscribeFrame,
 )
+from stompman.processing import AsyncProcessContext
 
 
 class Heartbeat(NamedTuple):
@@ -294,6 +295,9 @@ class MessageEvent:
 
     def __post_init__(self) -> None:
         self.body = self._frame.body
+
+    def process(self, ack_on_error: bool = False) -> AsyncProcessContext:
+        return AsyncProcessContext(self, ack_on_error=ack_on_error)
 
     async def ack(self) -> None:
         if self._client._connection.active:  # noqa: SLF001

--- a/stompman/processing.py
+++ b/stompman/processing.py
@@ -1,0 +1,45 @@
+from types import TracebackType
+import typing
+
+if typing.TYPE_CHECKING:
+    from stompman import MessageEvent
+
+class AsyncProcessContext(typing.AsyncContextManager["MessageEvent"]):
+    event: "MessageEvent"
+    ack_on_error: bool
+    propagate_exception: bool
+
+    def __init__(
+        self,
+        event: "MessageEvent",
+        *,
+        ack_on_error: bool = False,
+        propagate_exception: bool = False,
+    ):
+        self.event = event
+        self.ack_on_error = ack_on_error
+        self.propagate_exception = propagate_exception
+
+    async def __aenter__(self) -> "MessageEvent":
+        return self.event
+
+    async def __aexit__(
+        self,
+        __exc_type: type[BaseException] | None,
+        __exc_value: BaseException | None,
+        __traceback: TracebackType | None
+    ) -> bool | None:
+        if __exc_type is None:
+            await self.event.ack()
+            return True
+
+        if self.ack_on_error:
+            await self.event.ack()
+        else:
+            await self.event.nack()
+
+        if self.propagate_exception:
+            return False
+
+        return True
+

--- a/stompman/processing.py
+++ b/stompman/processing.py
@@ -1,45 +1,48 @@
-from types import TracebackType
 import typing
+from types import TracebackType
 
 if typing.TYPE_CHECKING:
     from stompman import MessageEvent
 
+E_co = typing.TypeVar("E_co", bound=BaseException, covariant=True)
+
+
 class AsyncProcessContext(typing.AsyncContextManager["MessageEvent"]):
     event: "MessageEvent"
-    ack_on_error: bool
-    propagate_exception: bool
+    on_suppressed_exception: typing.Callable[[E_co, "MessageEvent"], typing.Any]
+    supressed_exception_classes: tuple[type[Exception], ...] = (Exception,)
 
     def __init__(
         self,
         event: "MessageEvent",
         *,
-        ack_on_error: bool = False,
-        propagate_exception: bool = False,
-    ):
+        on_suppressed_exception: typing.Callable[[E_co, "MessageEvent"], typing.Any],
+        supressed_exception_classes: tuple[type[Exception], ...] = (Exception,),
+    ) -> None:
         self.event = event
-        self.ack_on_error = ack_on_error
-        self.propagate_exception = propagate_exception
+        self.on_suppressed_exception = on_suppressed_exception  # type: ignore[assignment]
+        self.supressed_exception_classes = supressed_exception_classes
 
     async def __aenter__(self) -> "MessageEvent":
         return self.event
 
     async def __aexit__(
-        self,
-        __exc_type: type[BaseException] | None,
-        __exc_value: BaseException | None,
-        __traceback: TracebackType | None
+        self, exc_type: type[BaseException] | None, exc_value: BaseException | None, __traceback: TracebackType | None
     ) -> bool | None:
-        if __exc_type is None:
-            await self.event.ack()
-            return True
+        called_nack = False
+        exception_suppressed = True
 
-        if self.ack_on_error:
-            await self.event.ack()
-        else:
+        if exc_type is not None and exc_value is not None:
+            if not issubclass(exc_type, self.supressed_exception_classes):
+                await self.event.ack()
+                return False
+
+            called_nack = True
+            exception_suppressed = True
             await self.event.nack()
+            self.on_suppressed_exception(exc_value, self.event)
 
-        if self.propagate_exception:
-            return False
+        if not called_nack:
+            await self.event.ack()
 
-        return True
-
+        return exception_suppressed


### PR DESCRIPTION
Hi Lev! 
This MR aiming only one opportunity – add support for context manager to ack / nack message in same manner it is done in [aio_pika](https://aio-pika.readthedocs.io/en/latest/quick-start.html#simple-consumer) since it's more "pythonic way", still following your original error handling semantics:
```python
async with asyncio.TaskGroup() as task_group:
    async for event in client.listen():
        match event:
            case stompman.MessageEvent(body=body):
                async with event.process(on_suppressed_exception=error_handler):
                    task_group.create_task(handle_message(body))
            case stompman.ErrorEvent():
                log.error("Received an error from server", stompman_event=event)
            case stompman.HeartbeatEvent():
                task_group.create_task(update_healthcheck_status())

async def error_handler(exc: Exception, event: stompman.MessageEvent) -> None:
    log.exception("Failed to process message", stompman_event=event)

async def handle_message(event: stompman.MessageEvent) -> None:
    validated_message = MyMessageModel.model_validate_json(event.body)
    await run_business_logic(validated_message)
```
It also keeps `event.with_auto_ack` for backward compatability, but uses context manager internally in it