### PR TITLE
Avoid escaping headers in CONNECT frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Also, I want to pointed out that:
 
 - Protocol parsing is inspired by [aiostomp](https://github.com/pedrokiefer/aiostomp/blob/3449dcb53f43e5956ccc7662bb5b7d76bc6ef36b/aiostomp/protocol.py) (meaning: consumed by me and refactored from).
 - stompman is tested and used with [Artemis ActiveMQ](https://activemq.apache.org/components/artemis/).
+- Specification says that headers in CONNECT and CONNECTED frames shouldn't be escaped for backwards compatibility. stompman doesn't escape headers in CONNECT frame (outcoming), but does not unescape headers in CONNECTED (outcoming).
 
 ## No docs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     image: apache/activemq-artemis:2.34.0-alpine
     environment:
       ARTEMIS_USER: admin
-      ARTEMIS_PASSWORD: =123
+      ARTEMIS_PASSWORD: ":=123"
     ports:
       - 8161:8161
       - 61616:61616

--- a/stompman/serde.py
+++ b/stompman/serde.py
@@ -80,10 +80,16 @@ def dump_header(key: str, value: str) -> bytes:
 
 
 def dump_frame(frame: AnyClientFrame | AnyServerFrame) -> bytes:
+    sorted_headers = sorted(frame.headers.items())
+    dumped_headers = (
+        (f"{key}:{value}\n".encode() for key, value in sorted_headers)
+        if isinstance(frame, ConnectFrame)
+        else (dump_header(key, cast(str, value)) for key, value in sorted_headers)
+    )
     lines = (
         FRAMES_TO_COMMANDS[type(frame)],
         NEWLINE,
-        *(dump_header(key, cast(str, value)) for key, value in sorted(frame.headers.items())),
+        *dumped_headers,
         NEWLINE,
         frame.body if isinstance(frame, FRAMES_WITH_BODY) else b"",
         NULL,

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -25,7 +25,7 @@ from stompman.serde import (
 pytestmark = pytest.mark.anyio
 
 CONNECTION_PARAMETERS: Final = stompman.ConnectionParameters(
-    host=os.environ["ARTEMIS_HOST"], port=61616, login="admin", passcode="%3D123"
+    host=os.environ["ARTEMIS_HOST"], port=61616, login="admin", passcode=":=123"
 )
 
 
@@ -163,9 +163,11 @@ headers_strategy = strategies.dictionaries(header_value_strategy, header_value_s
         if (parsed_header := parse_header(bytearray(header)))
     )
 )
+
+FRAMES_WITH_ESCAPED_HEADERS = tuple(command for command in COMMANDS_TO_FRAMES if command != b"CONNECT")
 frame_strategy = strategies.just(HeartbeatFrame()) | strategies.builds(
     make_frame_from_parts,
-    command=strategies.sampled_from(tuple(COMMANDS_TO_FRAMES.keys())),
+    command=strategies.sampled_from(FRAMES_WITH_ESCAPED_HEADERS),
     headers=headers_strategy,
     body=strategies.binary().filter(bytes_not_contains(NULL)),
 )


### PR DESCRIPTION
This fixes the issue where password in CONNECT frame would be escaped and authorization would fail.