### PR TITLE
Remove `frozen=True` and `slots=True` from exceptions to avoid triggering context manager traceback issue

### DIFF
--- a/stompman/errors.py
+++ b/stompman/errors.py
@@ -7,30 +7,30 @@ if TYPE_CHECKING:
     from stompman.config import ConnectionParameters
 
 
-@dataclass(frozen=True, kw_only=True, slots=True)
+@dataclass(kw_only=True)
 class Error(Exception):
     def __str__(self) -> str:
         return self.__repr__()
 
 
-@dataclass(frozen=True, kw_only=True, slots=True)
+@dataclass(kw_only=True)
 class ConnectionLostError(Error):
     """Raised in stompman.AbstractConnection—and handled in stompman.ConnectionManager, therefore is private."""
 
 
-@dataclass(frozen=True, kw_only=True, slots=True)
+@dataclass(kw_only=True)
 class ConnectionConfirmationTimeoutError(Error):
     timeout: int
     frames: list[MessageFrame | ReceiptFrame | ErrorFrame | HeartbeatFrame]
 
 
-@dataclass(frozen=True, kw_only=True, slots=True)
+@dataclass(kw_only=True)
 class UnsupportedProtocolVersionError(Error):
     given_version: str
     supported_version: str
 
 
-@dataclass(frozen=True, kw_only=True, slots=True)
+@dataclass(kw_only=True)
 class FailedAllConnectAttemptsError(Error):
     servers: list["ConnectionParameters"]
     retry_attempts: int
@@ -38,6 +38,6 @@ class FailedAllConnectAttemptsError(Error):
     timeout: int
 
 
-@dataclass(frozen=True, kw_only=True, slots=True)
+@dataclass(kw_only=True)
 class RepeatedConnectionLostError(Error):
     retry_attempts: int


### PR DESCRIPTION
```diff
Traceback (most recent call last):
    File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/contextlib.py", line 231, in __aexit__
      await self.gen.athrow(value)
    File "/Users/lev/code/stompman/stompman/client.py", line 323, in begin
      yield transaction
    File "/Users/lev/code/stompman/testing/producer.py", line 16, in main
      raise ConnectionLostError
  stompman.errors.ConnectionLostError: ConnectionLostError()
- 
- During handling of the above exception, another exception occurred:
- 
- Traceback (most recent call last):
-   File "/Users/lev/code/stompman/testing/producer.py", line 19, in <module>
-     asyncio.run(main())
-   File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 194, in run
-     return runner.run(main)
-            ^^^^^^^^^^^^^^^^
-   File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 118, in run
-     return self._loop.run_until_complete(task)
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
-     return future.result()
-            ^^^^^^^^^^^^^^^
-   File "/Users/lev/code/stompman/testing/producer.py", line 11, in main
-     async with stompman.Client(servers=[CONNECTION_PARAMETERS]) as client, client.begin() as transaction:
-   File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/contextlib.py", line 264, in __aexit__
-     exc.__traceback__ = traceback
-     ^^^^^^^^^^^^^^^^^
-   File "<string>", line 5, in __setattr__
- TypeError: super(type, obj): obj must be an instance or subtype of type
```