### PR TITLE
Refactor lifespan and errors 

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ stompman takes care of cleaning up resources automatically. When you leave the c
 
 - If multiple servers were provided, stompman will attempt to connect to each one simultaneously and will use the first that succeeds. If all servers fail to connect, an `stompman.FailedAllConnectAttemptsError` will be raised. In normal situation it doesn't need to be handled: tune retry and timeout parameters in `stompman.Client()` to your needs.
 
-- When connection is lost, stompman will handle it automatically. `stompman.FailedAllConnectAttemptsError` will be raised if all connection attempts fail. `stompman.RepeatedConnectionLostError` will be raised if connection succeeds but operation (like sending a frame) leads to connection getting lost.
+- When connection is lost, stompman will handle it automatically. `stompman.FailedAllConnectAttemptsError` will be raised if all connection attempts fail. `stompman.RepeatedConnectionLostError` or `stompman.ConnectionLostDuringOperationError` will be raised if connection succeeds but operation (like sending a frame) leads to connection getting lost.
 
 ### ...and caveats
 

--- a/stompman/__init__.py
+++ b/stompman/__init__.py
@@ -9,6 +9,7 @@ from stompman.errors import (
     ConnectionLostError,
     Error,
     FailedAllConnectAttemptsError,
+    StompProtocolConnectionIssue,
     UnsupportedProtocolVersion,
 )
 from stompman.frames import (
@@ -66,6 +67,7 @@ __all__ = [
     "NackFrame",
     "ReceiptFrame",
     "SendFrame",
+    "StompProtocolConnectionIssue",
     "SubscribeFrame",
     "Subscription",
     "Transaction",

--- a/stompman/__init__.py
+++ b/stompman/__init__.py
@@ -1,14 +1,15 @@
-from stompman.client import Client, Subscription, Transaction
+from stompman.client import Client, ConnectionLifespan, Subscription, Transaction
 from stompman.config import ConnectionParameters, Heartbeat
 from stompman.connection import AbstractConnection, Connection
-from stompman.connection_manager import ActiveConnectionState, ConnectionManager
+from stompman.connection_manager import AbstractConnectionLifespan, ActiveConnectionState, ConnectionManager
 from stompman.errors import (
-    ConnectionConfirmationTimeoutError,
+    ConnectionConfirmationTimeout,
     ConnectionLostError,
     Error,
     FailedAllConnectAttemptsError,
+    RepeatedConnectionFailedError,
     RepeatedConnectionLostError,
-    UnsupportedProtocolVersionError,
+    UnsupportedProtocolVersion,
 )
 from stompman.frames import (
     AbortFrame,
@@ -35,6 +36,7 @@ from stompman.frames import (
 __all__ = [
     "AbortFrame",
     "AbstractConnection",
+    "AbstractConnectionLifespan",
     "AckFrame",
     "AckMode",
     "ActiveConnectionState",
@@ -47,7 +49,8 @@ __all__ = [
     "ConnectFrame",
     "ConnectedFrame",
     "Connection",
-    "ConnectionConfirmationTimeoutError",
+    "ConnectionConfirmationTimeout",
+    "ConnectionLifespan",
     "ConnectionLostError",
     "ConnectionManager",
     "ConnectionParameters",
@@ -60,11 +63,12 @@ __all__ = [
     "MessageFrame",
     "NackFrame",
     "ReceiptFrame",
+    "RepeatedConnectionFailedError",
     "RepeatedConnectionLostError",
     "SendFrame",
     "SubscribeFrame",
     "Subscription",
     "Transaction",
     "UnsubscribeFrame",
-    "UnsupportedProtocolVersionError",
+    "UnsupportedProtocolVersion",
 ]

--- a/stompman/__init__.py
+++ b/stompman/__init__.py
@@ -1,7 +1,12 @@
 from stompman.client import Client, ConnectionLifespan, Subscription, Transaction
 from stompman.config import ConnectionParameters, Heartbeat
 from stompman.connection import AbstractConnection, Connection
-from stompman.connection_manager import AbstractConnectionLifespan, ActiveConnectionState, ConnectionManager
+from stompman.connection_manager import (
+    AbstractConnectionLifespan,
+    ActiveConnectionState,
+    ConnectionLifespanFactory,
+    ConnectionManager,
+)
 from stompman.errors import (
     ConnectionAttemptsFailedError,
     ConnectionConfirmationTimeout,
@@ -33,6 +38,7 @@ from stompman.frames import (
     SubscribeFrame,
     UnsubscribeFrame,
 )
+from stompman.serde import FrameParser, dump_frame
 
 __all__ = [
     "AbortFrame",
@@ -53,6 +59,7 @@ __all__ = [
     "ConnectionAttemptsFailedError",
     "ConnectionConfirmationTimeout",
     "ConnectionLifespan",
+    "ConnectionLifespanFactory",
     "ConnectionLostDuringOperationError",
     "ConnectionLostError",
     "ConnectionManager",
@@ -61,6 +68,7 @@ __all__ = [
     "Error",
     "ErrorFrame",
     "FailedAllConnectAttemptsError",
+    "FrameParser",
     "Heartbeat",
     "HeartbeatFrame",
     "MessageFrame",
@@ -73,4 +81,5 @@ __all__ = [
     "Transaction",
     "UnsubscribeFrame",
     "UnsupportedProtocolVersion",
+    "dump_frame",
 ]

--- a/stompman/__init__.py
+++ b/stompman/__init__.py
@@ -3,12 +3,12 @@ from stompman.config import ConnectionParameters, Heartbeat
 from stompman.connection import AbstractConnection, Connection
 from stompman.connection_manager import AbstractConnectionLifespan, ActiveConnectionState, ConnectionManager
 from stompman.errors import (
+    ConnectionAttemptsFailedError,
     ConnectionConfirmationTimeout,
+    ConnectionLostDuringOperationError,
     ConnectionLostError,
     Error,
     FailedAllConnectAttemptsError,
-    RepeatedConnectionFailedError,
-    RepeatedConnectionLostError,
     UnsupportedProtocolVersion,
 )
 from stompman.frames import (
@@ -49,8 +49,10 @@ __all__ = [
     "ConnectFrame",
     "ConnectedFrame",
     "Connection",
+    "ConnectionAttemptsFailedError",
     "ConnectionConfirmationTimeout",
     "ConnectionLifespan",
+    "ConnectionLostDuringOperationError",
     "ConnectionLostError",
     "ConnectionManager",
     "ConnectionParameters",
@@ -63,8 +65,6 @@ __all__ = [
     "MessageFrame",
     "NackFrame",
     "ReceiptFrame",
-    "RepeatedConnectionFailedError",
-    "RepeatedConnectionLostError",
     "SendFrame",
     "SubscribeFrame",
     "Subscription",

--- a/stompman/client.py
+++ b/stompman/client.py
@@ -201,7 +201,7 @@ class ConnectionLifespan(AbstractConnectionLifespan):
             return ConnectionLost()
         return None
 
-    async def close(self) -> None:
+    async def exit(self) -> None:
         await self.connection.write_frame(DisconnectFrame(headers={"receipt": _make_receipt_id()}))
 
         async def take_receipt_frame() -> None:

--- a/stompman/client.py
+++ b/stompman/client.py
@@ -10,13 +10,7 @@ from uuid import uuid4
 from stompman.config import ConnectionParameters, Heartbeat
 from stompman.connection import AbstractConnection, Connection
 from stompman.connection_manager import AbstractConnectionLifespan, ConnectionManager
-from stompman.errors import (
-    ConnectionConfirmationTimeout,
-    ConnectionIssue,
-    ConnectionLost,
-    ConnectionLostError,
-    UnsupportedProtocolVersion,
-)
+from stompman.errors import ConnectionConfirmationTimeout, ConnectionIssue, UnsupportedProtocolVersion
 from stompman.frames import (
     AbortFrame,
     AckFrame,

--- a/stompman/client.py
+++ b/stompman/client.py
@@ -192,13 +192,10 @@ class ConnectionLifespan(AbstractConnectionLifespan):
         self.active_transactions.clear()
 
     async def enter(self) -> ConnectionIssue | None:
-        try:
-            if connection_issue := await self._establish_connection():
-                return connection_issue
-            await self._resubscribe()
-            await self._commit_pending_transactions()
-        except ConnectionLostError:
-            return ConnectionLost()
+        if connection_issue := await self._establish_connection():
+            return connection_issue
+        await self._resubscribe()
+        await self._commit_pending_transactions()
         return None
 
     async def exit(self) -> None:

--- a/stompman/client.py
+++ b/stompman/client.py
@@ -2,14 +2,23 @@ import asyncio
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from dataclasses import dataclass, field
+from functools import partial
 from types import TracebackType
 from typing import ClassVar, Self
 from uuid import uuid4
 
 from stompman.config import ConnectionParameters, Heartbeat
 from stompman.connection import AbstractConnection, Connection
-from stompman.connection_manager import ConnectionManager
-from stompman.errors import ConnectionConfirmationTimeoutError, UnsupportedProtocolVersionError
+from stompman.connection_manager import AbstractConnectionLifespan, ConnectionManager
+from stompman.errors import (
+    ConnectionConfirmationTimeout,
+    ConnectionConfirmationTimeoutError,
+    ConnectionIssue,
+    ConnectionLost,
+    ConnectionLostError,
+    UnsupportedProtocolVersion,
+    UnsupportedProtocolVersionError,
+)
 from stompman.frames import (
     AbortFrame,
     AckFrame,
@@ -207,6 +216,98 @@ async def commit_pending_transactions(*, connection: AbstractConnection, active_
 
 
 @dataclass(kw_only=True, slots=True)
+class ConnectionLifespan(AbstractConnectionLifespan):
+    connection: AbstractConnection
+    connection_parameters: ConnectionParameters
+    protocol_version: str
+    client_heartbeat: Heartbeat
+    connection_confirmation_timeout: int
+    disconnect_confirmation_timeout: int
+    active_subscriptions: dict[str, Subscription]
+    active_transactions: set[Transaction]
+    set_heartbeat: Callable[[float], None]
+
+    async def _establish_connection(self) -> ConnectionIssue | None:
+        await self.connection.write_frame(
+            ConnectFrame(
+                headers={
+                    "accept-version": self.protocol_version,
+                    "heart-beat": self.client_heartbeat.to_header(),
+                    "host": self.connection_parameters.host,
+                    "login": self.connection_parameters.login,
+                    "passcode": self.connection_parameters.unescaped_passcode,
+                },
+            )
+        )
+        collected_frames = []
+
+        async def take_connected_frame_and_collect_other_frames() -> ConnectedFrame:
+            async for frame in self.connection.read_frames():
+                if isinstance(frame, ConnectedFrame):
+                    return frame
+                collected_frames.append(frame)
+            msg = "unreachable"  # pragma: no cover
+            raise AssertionError(msg)  # pragma: no cover
+
+        try:
+            connected_frame = await asyncio.wait_for(
+                take_connected_frame_and_collect_other_frames(), timeout=self.connection_confirmation_timeout
+            )
+        except TimeoutError:
+            return ConnectionConfirmationTimeout(timeout=self.connection_confirmation_timeout, frames=collected_frames)
+
+        if connected_frame.headers["version"] != self.protocol_version:
+            return UnsupportedProtocolVersion(
+                given_version=connected_frame.headers["version"], supported_version=self.protocol_version
+            )
+
+        server_heartbeat = Heartbeat.from_header(connected_frame.headers["heart-beat"])
+        self.set_heartbeat(
+            max(self.client_heartbeat.will_send_interval_ms, server_heartbeat.want_to_receive_interval_ms) / 1000
+        )
+        return None
+
+    async def _resubscribe(self) -> None:
+        for subscription in self.active_subscriptions.values():
+            await self.connection.write_frame(
+                SubscribeFrame(
+                    headers={"id": subscription.id, "destination": subscription.destination, "ack": subscription.ack}
+                )
+            )
+
+    async def _commit_pending_transactions(self) -> None:
+        for transaction in self.active_transactions:
+            for frame in transaction.sent_frames:
+                await self.connection.write_frame(frame)
+            await self.connection.write_frame(CommitFrame(headers={"transaction": transaction.id}))
+        self.active_transactions.clear()
+
+    async def enter(self) -> ConnectionIssue | None:
+        try:
+            if connection_issue := await self._establish_connection():
+                return connection_issue
+            await self._resubscribe()
+            await self._commit_pending_transactions()
+        except ConnectionLostError:
+            return ConnectionLost()
+        return None
+
+    async def close(self) -> None:
+        await self.connection.write_frame(DisconnectFrame(headers={"receipt": _make_receipt_id()}))
+
+        async def take_receipt_frame() -> None:
+            async for frame in self.connection.read_frames():
+                if isinstance(frame, ReceiptFrame):
+                    break
+
+        with suppress(TimeoutError):
+            await asyncio.wait_for(take_receipt_frame(), timeout=self.disconnect_confirmation_timeout)
+
+        for subscription in self.active_subscriptions.copy().values():
+            await subscription.unsubscribe()
+
+
+@dataclass(kw_only=True, slots=True)
 class Client:
     PROTOCOL_VERSION: ClassVar = "1.2"  # https://stomp.github.io/stomp-specification-1.2.html
 
@@ -236,7 +337,16 @@ class Client:
     def __post_init__(self) -> None:
         self._connection_manager = ConnectionManager(
             servers=self.servers,
-            lifespan=self._lifespan,
+            lifespan_factory=partial(
+                ConnectionLifespan,
+                protocol_version=self.PROTOCOL_VERSION,
+                client_heartbeat=self.heartbeat,
+                connection_confirmation_timeout=self.connection_confirmation_timeout,
+                disconnect_confirmation_timeout=self.disconnect_confirmation_timeout,
+                active_subscriptions=self._active_subscriptions,
+                active_transactions=self._active_transactions,
+                set_heartbeat=self._restart_heartbeat_task,
+            ),
             connection_class=self.connection_class,
             connect_retry_attempts=self.connect_retry_attempts,
             connect_retry_interval=self.connect_retry_interval,

--- a/stompman/client.py
+++ b/stompman/client.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 from stompman.config import ConnectionParameters, Heartbeat
 from stompman.connection import AbstractConnection, Connection
 from stompman.connection_manager import AbstractConnectionLifespan, ConnectionManager
-from stompman.errors import ConnectionConfirmationTimeout, ConnectionIssue, UnsupportedProtocolVersion
+from stompman.errors import ConnectionConfirmationTimeout, StompProtocolConnectionIssue, UnsupportedProtocolVersion
 from stompman.frames import (
     AbortFrame,
     AckFrame,
@@ -130,7 +130,7 @@ class ConnectionLifespan(AbstractConnectionLifespan):
     active_transactions: set[Transaction]
     set_heartbeat: Callable[[float], None]
 
-    async def _establish_connection(self) -> ConnectionIssue | None:
+    async def _establish_connection(self) -> StompProtocolConnectionIssue | None:
         await self.connection.write_frame(
             ConnectFrame(
                 headers={
@@ -185,7 +185,7 @@ class ConnectionLifespan(AbstractConnectionLifespan):
             await self.connection.write_frame(CommitFrame(headers={"transaction": transaction.id}))
         self.active_transactions.clear()
 
-    async def enter(self) -> ConnectionIssue | None:
+    async def enter(self) -> StompProtocolConnectionIssue | None:
         if connection_issue := await self._establish_connection():
             return connection_issue
         await self._resubscribe()

--- a/stompman/connection_manager.py
+++ b/stompman/connection_manager.py
@@ -115,6 +115,7 @@ class ConnectionManager:
                     connection_issues.append(ConnectionLost())
                 else:
                     if lifespan_connection_issue:
+                        self._clear_active_connection_state()
                         connection_issues.append(lifespan_connection_issue)
                     else:
                         return self._active_connection_state

--- a/stompman/errors.py
+++ b/stompman/errors.py
@@ -54,7 +54,7 @@ class UnsupportedProtocolVersion:
 class ConnectionLost: ...
 
 
-ConnectionIssue = ConnectionConfirmationTimeout | UnsupportedProtocolVersion | ConnectionLost
+ConnectionIssue = ConnectionConfirmationTimeout | UnsupportedProtocolVersion
 
 
 @dataclass(kw_only=True)

--- a/stompman/errors.py
+++ b/stompman/errors.py
@@ -19,18 +19,6 @@ class ConnectionLostError(Error):
 
 
 @dataclass(kw_only=True)
-class ConnectionConfirmationTimeoutError(Error):
-    timeout: int
-    frames: list[MessageFrame | ReceiptFrame | ErrorFrame | HeartbeatFrame]
-
-
-@dataclass(kw_only=True)
-class UnsupportedProtocolVersionError(Error):
-    given_version: str
-    supported_version: str
-
-
-@dataclass(kw_only=True)
 class FailedAllConnectAttemptsError(Error):
     servers: list["ConnectionParameters"]
     retry_attempts: int
@@ -54,7 +42,13 @@ class UnsupportedProtocolVersion:
 class ConnectionLost: ...
 
 
-ConnectionIssue = ConnectionConfirmationTimeout | UnsupportedProtocolVersion
+StompProtocolConnectionIssue = ConnectionConfirmationTimeout | UnsupportedProtocolVersion
+
+
+@dataclass(kw_only=True)
+class RepeatedConnectionFailedError(Error):
+    retry_attempts: int
+    issues: list[StompProtocolConnectionIssue | ConnectionLost]
 
 
 @dataclass(kw_only=True)

--- a/stompman/errors.py
+++ b/stompman/errors.py
@@ -38,6 +38,25 @@ class FailedAllConnectAttemptsError(Error):
     timeout: int
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ConnectionConfirmationTimeout:
+    timeout: int
+    frames: list[MessageFrame | ReceiptFrame | ErrorFrame | HeartbeatFrame]
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class UnsupportedProtocolVersion:
+    given_version: str
+    supported_version: str
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ConnectionLost: ...
+
+
+ConnectionIssue = ConnectionConfirmationTimeout | UnsupportedProtocolVersion | ConnectionLost
+
+
 @dataclass(kw_only=True)
 class RepeatedConnectionLostError(Error):
     retry_attempts: int

--- a/stompman/errors.py
+++ b/stompman/errors.py
@@ -46,11 +46,11 @@ StompProtocolConnectionIssue = ConnectionConfirmationTimeout | UnsupportedProtoc
 
 
 @dataclass(kw_only=True)
-class RepeatedConnectionFailedError(Error):
+class ConnectionAttemptsFailedError(Error):
     retry_attempts: int
     issues: list[StompProtocolConnectionIssue | ConnectionLost]
 
 
 @dataclass(kw_only=True)
-class RepeatedConnectionLostError(Error):
+class ConnectionLostDuringOperationError(Error):
     retry_attempts: int

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ class EnrichedClient(stompman.Client):
 async def noop_lifespan(  # noqa: RUF029
     connection: stompman.AbstractConnection, connection_parameters: stompman.ConnectionParameters
 ) -> AsyncIterator[None]:
-    yield
+    yield  # pragma: no cover
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from polyfactory.factories.dataclass_factory import DataclassFactory
 
 import stompman
 from stompman.connection_manager import AbstractConnectionLifespan, ConnectionLifespanFactory
-from stompman.errors import ConnectionIssue
+from stompman.errors import StompProtocolConnectionIssue
 from stompman.frames import HeartbeatFrame
 
 
@@ -70,7 +70,7 @@ class NoopLifespan(AbstractConnectionLifespan):
     connection: stompman.AbstractConnection
     connection_parameters: stompman.ConnectionParameters
 
-    async def enter(self) -> ConnectionIssue | None: ...
+    async def enter(self) -> StompProtocolConnectionIssue | None: ...
     async def exit(self) -> None: ...
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,9 @@ import pytest
 from polyfactory.factories.dataclass_factory import DataclassFactory
 
 import stompman
+from stompman import HeartbeatFrame
 from stompman.connection_manager import AbstractConnectionLifespan, ConnectionLifespanFactory
 from stompman.errors import StompProtocolConnectionIssue
-from stompman.frames import HeartbeatFrame
 
 
 @pytest.fixture(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import asyncio
-from collections.abc import AsyncGenerator, AsyncIterator
-from contextlib import asynccontextmanager
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from typing import Any, Self, TypeVar
 from unittest import mock
@@ -56,13 +55,6 @@ class EnrichedClient(stompman.Client):
     servers: list[stompman.ConnectionParameters] = field(
         default_factory=lambda: [stompman.ConnectionParameters("localhost", 12345, "login", "passcode")], kw_only=False
     )
-
-
-@asynccontextmanager
-async def noop_lifespan(  # noqa: RUF029
-    connection: stompman.AbstractConnection, connection_parameters: stompman.ConnectionParameters
-) -> AsyncIterator[None]:
-    yield  # pragma: no cover
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,6 @@ import pytest
 from polyfactory.factories.dataclass_factory import DataclassFactory
 
 import stompman
-from stompman import HeartbeatFrame
-from stompman.connection_manager import AbstractConnectionLifespan, ConnectionLifespanFactory
-from stompman.errors import StompProtocolConnectionIssue
 
 
 @pytest.fixture(
@@ -47,7 +44,7 @@ class BaseMockConnection(stompman.AbstractConnection):
     @staticmethod
     async def read_frames() -> AsyncGenerator[stompman.AnyServerFrame, None]:  # pragma: no cover
         await asyncio.Future()
-        yield HeartbeatFrame()
+        yield stompman.HeartbeatFrame()
 
 
 @dataclass(kw_only=True, slots=True)
@@ -58,11 +55,11 @@ class EnrichedClient(stompman.Client):
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
-class NoopLifespan(AbstractConnectionLifespan):
+class NoopLifespan(stompman.AbstractConnectionLifespan):
     connection: stompman.AbstractConnection
     connection_parameters: stompman.ConnectionParameters
 
-    async def enter(self) -> StompProtocolConnectionIssue | None: ...
+    async def enter(self) -> stompman.StompProtocolConnectionIssue | None: ...
     async def exit(self) -> None: ...
 
 
@@ -71,7 +68,7 @@ class EnrichedConnectionManager(stompman.ConnectionManager):
     servers: list[stompman.ConnectionParameters] = field(
         default_factory=lambda: [stompman.ConnectionParameters("localhost", 12345, "login", "passcode")]
     )
-    lifespan_factory: ConnectionLifespanFactory = field(default=NoopLifespan)
+    lifespan_factory: stompman.ConnectionLifespanFactory = field(default=NoopLifespan)
     connect_retry_attempts: int = 3
     connect_retry_interval: int = 1
     connect_timeout: int = 3

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,6 +21,8 @@ from stompman import (
     CommitFrame,
     ConnectedFrame,
     ConnectFrame,
+    ConnectionAttemptsFailedError,
+    ConnectionConfirmationTimeout,
     ConnectionParameters,
     DisconnectFrame,
     ErrorFrame,
@@ -32,8 +34,8 @@ from stompman import (
     SendFrame,
     SubscribeFrame,
     UnsubscribeFrame,
+    UnsupportedProtocolVersion,
 )
-from stompman.errors import ConnectionAttemptsFailedError, ConnectionConfirmationTimeout, UnsupportedProtocolVersion
 from tests.conftest import (
     BaseMockConnection,
     EnrichedClient,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,7 +21,6 @@ from stompman import (
     CommitFrame,
     ConnectedFrame,
     ConnectFrame,
-    ConnectionConfirmationTimeoutError,
     ConnectionParameters,
     DisconnectFrame,
     ErrorFrame,
@@ -33,8 +32,8 @@ from stompman import (
     SendFrame,
     SubscribeFrame,
     UnsubscribeFrame,
-    UnsupportedProtocolVersionError,
 )
+from stompman.errors import ConnectionConfirmationTimeout, RepeatedConnectionFailedError, UnsupportedProtocolVersion
 from tests.conftest import (
     BaseMockConnection,
     EnrichedClient,
@@ -150,28 +149,31 @@ async def test_client_connection_lifespan_connection_not_confirmed(monkeypatch: 
             yield error_frame
             await asyncio.sleep(0)
 
-    with pytest.raises(ConnectionConfirmationTimeoutError) as exc_info:
+    with pytest.raises(RepeatedConnectionFailedError) as exc_info:
         await EnrichedClient(
             connection_class=MockConnection, connection_confirmation_timeout=connection_confirmation_timeout
         ).__aenter__()
 
-    assert exc_info.value == ConnectionConfirmationTimeoutError(
-        timeout=connection_confirmation_timeout, frames=[error_frame]
+    assert exc_info.value == RepeatedConnectionFailedError(
+        retry_attempts=3,
+        issues=[ConnectionConfirmationTimeout(timeout=connection_confirmation_timeout, frames=[error_frame])] * 3,
     )
 
 
 async def test_client_connection_lifespan_unsupported_protocol_version() -> None:
     given_version = FAKER.pystr()
 
-    with pytest.raises(UnsupportedProtocolVersionError) as exc_info:
+    with pytest.raises(RepeatedConnectionFailedError) as exc_info:
         await EnrichedClient(
             connection_class=create_spying_connection(
                 [build_dataclass(ConnectedFrame, headers={"version": given_version})]
-            )[0]
+            )[0],
+            connect_retry_attempts=1,
         ).__aenter__()
 
-    assert exc_info.value == UnsupportedProtocolVersionError(
-        given_version=given_version, supported_version=Client.PROTOCOL_VERSION
+    assert exc_info.value == RepeatedConnectionFailedError(
+        retry_attempts=1,
+        issues=[UnsupportedProtocolVersion(given_version=given_version, supported_version=Client.PROTOCOL_VERSION)],
     )
 
 

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -9,15 +9,15 @@ from stompman import (
     AnyServerFrame,
     ConnectedFrame,
     ConnectFrame,
+    ConnectionLostDuringOperationError,
     ConnectionLostError,
     ConnectionParameters,
     ErrorFrame,
     FailedAllConnectAttemptsError,
     MessageFrame,
-    RepeatedConnectionLostError,
 )
 from stompman.connection_manager import ActiveConnectionState
-from stompman.errors import RepeatedConnectionFailedError
+from stompman.errors import ConnectionAttemptsFailedError
 from tests.conftest import BaseMockConnection, EnrichedConnectionManager, build_dataclass
 
 pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("mock_sleep")]
@@ -133,7 +133,7 @@ async def test_get_active_connection_state_lifespan_flaky_fails() -> None:
     lifespan_factory = mock.Mock(return_value=mock.Mock(enter=enter))
     manager = EnrichedConnectionManager(lifespan_factory=lifespan_factory, connection_class=BaseMockConnection)
 
-    with pytest.raises(RepeatedConnectionFailedError) as exc_info:
+    with pytest.raises(ConnectionAttemptsFailedError) as exc_info:
         await manager._get_active_connection_state()
 
     assert (
@@ -219,7 +219,7 @@ async def test_write_heartbeat_reconnecting_raises() -> None:
 
     manager = EnrichedConnectionManager(connection_class=MockConnection)
 
-    with pytest.raises(RepeatedConnectionLostError):
+    with pytest.raises(ConnectionLostDuringOperationError):
         await manager.write_heartbeat_reconnecting()
 
 
@@ -231,7 +231,7 @@ async def test_write_frame_reconnecting_raises() -> None:
 
     manager = EnrichedConnectionManager(connection_class=MockConnection)
 
-    with pytest.raises(RepeatedConnectionLostError):
+    with pytest.raises(ConnectionLostDuringOperationError):
         await manager.write_frame_reconnecting(build_dataclass(ConnectFrame))
 
 

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -1,6 +1,5 @@
 import asyncio
 from collections.abc import AsyncGenerator, AsyncIterable
-from types import SimpleNamespace
 from typing import Self
 from unittest import mock
 
@@ -18,6 +17,7 @@ from stompman import (
     RepeatedConnectionLostError,
 )
 from stompman.connection_manager import ActiveConnectionState
+from stompman.errors import RepeatedConnectionFailedError
 from tests.conftest import BaseMockConnection, EnrichedConnectionManager, build_dataclass
 
 pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("mock_sleep")]
@@ -115,31 +115,31 @@ async def test_connect_to_any_server_fails() -> None:
 
 
 async def test_get_active_connection_state_lifespan_flaky_ok() -> None:
-    aenter = mock.AsyncMock(side_effect=[ConnectionLostError, None])
-    lifespan = mock.Mock(return_value=SimpleNamespace(__aenter__=aenter))
-    manager = EnrichedConnectionManager(lifespan=lifespan, connection_class=BaseMockConnection)
+    enter = mock.AsyncMock(side_effect=[ConnectionLostError, None])
+    lifespan_factory = mock.Mock(return_value=mock.Mock(enter=enter))
+    manager = EnrichedConnectionManager(lifespan_factory=lifespan_factory, connection_class=BaseMockConnection)
 
     await manager._get_active_connection_state()
 
-    assert aenter.mock_calls == [mock.call(), mock.call()]
-    assert lifespan.mock_calls == [
-        mock.call(BaseMockConnection(), manager.servers[0]),
-        mock.call(BaseMockConnection(), manager.servers[0]),
+    assert enter.mock_calls == [mock.call(), mock.call()]
+    assert lifespan_factory.mock_calls == [
+        mock.call(connection=BaseMockConnection(), connection_parameters=manager.servers[0]),
+        mock.call(connection=BaseMockConnection(), connection_parameters=manager.servers[0]),
     ]
 
 
 async def test_get_active_connection_state_lifespan_flaky_fails() -> None:
-    aenter = mock.AsyncMock(side_effect=ConnectionLostError)
-    lifespan = mock.Mock(return_value=SimpleNamespace(__aenter__=aenter))
-    manager = EnrichedConnectionManager(lifespan=lifespan, connection_class=BaseMockConnection)
+    enter = mock.AsyncMock(side_effect=ConnectionLostError)
+    lifespan_factory = mock.Mock(return_value=mock.Mock(enter=enter))
+    manager = EnrichedConnectionManager(lifespan_factory=lifespan_factory, connection_class=BaseMockConnection)
 
-    with pytest.raises(RepeatedConnectionLostError) as exc_info:
+    with pytest.raises(RepeatedConnectionFailedError) as exc_info:
         await manager._get_active_connection_state()
 
     assert (
         exc_info.value.retry_attempts
-        == len(lifespan.mock_calls)
-        == len(aenter.mock_calls)
+        == len(lifespan_factory.mock_calls)
+        == len(enter.mock_calls)
         == manager.connect_retry_attempts
     )
 
@@ -153,9 +153,9 @@ async def test_get_active_connection_state_fails_to_connect() -> None:
 
 
 async def test_get_active_connection_state_ok_concurrent() -> None:
-    aenter = mock.AsyncMock(side_effect=None)
-    lifespan = mock.Mock(return_value=SimpleNamespace(__aenter__=aenter))
-    manager = EnrichedConnectionManager(lifespan=lifespan, connection_class=BaseMockConnection)
+    enter = mock.AsyncMock(return_value=None)
+    lifespan_factory = mock.Mock(return_value=mock.Mock(enter=enter))
+    manager = EnrichedConnectionManager(lifespan_factory=lifespan_factory, connection_class=BaseMockConnection)
 
     first_state, second_state, third_state = await asyncio.gather(
         manager._get_active_connection_state(),
@@ -169,12 +169,12 @@ async def test_get_active_connection_state_ok_concurrent() -> None:
         == second_state
         == third_state
         == fourth_state
-        == ActiveConnectionState(connection=BaseMockConnection(), lifespan=lifespan.return_value)
+        == ActiveConnectionState(connection=BaseMockConnection(), lifespan=lifespan_factory.return_value)
     )
     assert first_state is second_state is third_state is fourth_state
 
-    aenter.assert_called_once_with()
-    lifespan.assert_called_once_with(BaseMockConnection(), manager.servers[0])
+    enter.assert_called_once_with()
+    lifespan_factory.assert_called_once_with(connection=BaseMockConnection(), connection_parameters=manager.servers[0])
 
 
 async def test_connection_manager_context_connection_lost() -> None:
@@ -184,9 +184,9 @@ async def test_connection_manager_context_connection_lost() -> None:
 
 async def test_connection_manager_context_lifespan_aexit_raises_connection_lost() -> None:
     async with EnrichedConnectionManager(
-        lifespan=mock.Mock(
-            return_value=SimpleNamespace(
-                __aenter__=mock.AsyncMock(), __aexit__=mock.AsyncMock(side_effect=[ConnectionLostError])
+        lifespan_factory=mock.Mock(
+            return_value=mock.Mock(
+                enter=mock.AsyncMock(return_value=None), exit=mock.AsyncMock(side_effect=[ConnectionLostError])
             )
         ),
         connection_class=BaseMockConnection,
@@ -194,21 +194,21 @@ async def test_connection_manager_context_lifespan_aexit_raises_connection_lost(
         pass
 
 
-async def test_connection_manager_context_exist_ok() -> None:
-    aexit = mock.AsyncMock()
-    close_mock = mock.AsyncMock()
+async def test_connection_manager_context_exits_ok() -> None:
+    close = mock.AsyncMock()
+    connection_close = mock.AsyncMock()
 
     class MockConnection(BaseMockConnection):
-        close = close_mock
+        close = connection_close
 
     async with EnrichedConnectionManager(
-        lifespan=mock.Mock(return_value=SimpleNamespace(__aenter__=mock.AsyncMock(), __aexit__=aexit)),
+        lifespan_factory=mock.Mock(return_value=mock.Mock(enter=mock.AsyncMock(return_value=None), exit=close)),
         connection_class=MockConnection,
     ):
         pass
 
-    aexit.assert_called_once()
-    close_mock.assert_called_once_with()
+    close.assert_called_once()
+    connection_close.assert_called_once_with()
 
 
 async def test_write_heartbeat_reconnecting_raises() -> None:

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -6,9 +6,11 @@ from unittest import mock
 import pytest
 
 from stompman import (
+    ActiveConnectionState,
     AnyServerFrame,
     ConnectedFrame,
     ConnectFrame,
+    ConnectionAttemptsFailedError,
     ConnectionLostDuringOperationError,
     ConnectionLostError,
     ConnectionParameters,
@@ -16,8 +18,6 @@ from stompman import (
     FailedAllConnectAttemptsError,
     MessageFrame,
 )
-from stompman.connection_manager import ActiveConnectionState
-from stompman.errors import ConnectionAttemptsFailedError
 from tests.conftest import BaseMockConnection, EnrichedConnectionManager, build_dataclass
 
 pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("mock_sleep")]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,5 +2,5 @@ import stompman
 
 
 def test_error_str() -> None:
-    error = stompman.RepeatedConnectionFailedError(retry_attempts=1, issues=[])
+    error = stompman.ConnectionAttemptsFailedError(retry_attempts=1, issues=[])
     assert str(error) == repr(error)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,5 +2,5 @@ import stompman
 
 
 def test_error_str() -> None:
-    error = stompman.ConnectionConfirmationTimeoutError(timeout=1, frames=[])
+    error = stompman.RepeatedConnectionFailedError(retry_attempts=1, issues=[])
     assert str(error) == repr(error)

--- a/tests/test_frame_serde.py
+++ b/tests/test_frame_serde.py
@@ -7,10 +7,12 @@ from stompman import (
     ConnectedFrame,
     ConnectFrame,
     ErrorFrame,
+    FrameParser,
     HeartbeatFrame,
     MessageFrame,
+    dump_frame,
 )
-from stompman.serde import NEWLINE, FrameParser, dump_frame
+from stompman.serde import NEWLINE
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Rename RepeatedConnectionLostError to ConnectionLostDuringOperationError
- Merge ConnectionConfirmationTimeoutError, UnsupportedProtocolVersionError into ConnectionAttemptsFailedError that is raised if lifespan fails