### PR TITLE
Use PEP 735 dependency-groups.dev for dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,17 +19,16 @@ dynamic = ["version"]
 [project.urls]
 repository = "https://github.com/vrslev/stompman"
 
-[tool.uv]
-dev-dependencies = [
-    "anyio~=4.4.0",
-    "mypy~=1.11.2",
-    "pytest-cov~=5.0.0",
-    "pytest~=8.3.2",
-    "ruff~=0.6.2",
-    "uvloop~=0.21.0beta1",
-    "hypothesis~=6.111.2",
-    "polyfactory~=2.16.2",
-    "faker~=28.0.0",
+[dependency-groups]
+dev = [
+    "anyio>=4.6.2.post1",
+    "faker>=30.8.1",
+    "hypothesis>=6.115.5",
+    "mypy>=1.13.0",
+    "polyfactory>=2.17.0",
+    "pytest-cov>=5.0.0",
+    "ruff>=0.7.1",
+    "uvloop>=0.21.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,14 @@ repository = "https://github.com/vrslev/stompman"
 
 [dependency-groups]
 dev = [
-    "anyio>=4.6.2.post1",
-    "faker>=30.8.1",
-    "hypothesis>=6.115.5",
-    "mypy>=1.13.0",
-    "polyfactory>=2.17.0",
-    "pytest-cov>=5.0.0",
-    "ruff>=0.7.1",
-    "uvloop>=0.21.0",
+    "anyio==4.6.2.post1",
+    "faker==30.8.1",
+    "hypothesis==6.115.5",
+    "mypy==1.13.0",
+    "polyfactory==2.17.0",
+    "pytest-cov==5.0.0",
+    "ruff==0.7.1",
+    "uvloop==0.21.0",
 ]
 
 [build-system]


### PR DESCRIPTION
uv recently released new version that supports now standardized `[dependency-groups]` table. See [uv 0.4.27](https://github.com/astral-sh/uv/releases/tag/0.4.27) and [PEP 735](https://peps.python.org/pep-0735/)