### PR TITLE
Introduce `add_content_length=False` param in `send()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .venv
 dist
 uv.lock
+.vscode
+__pycache__

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Also, I want to pointed out that:
 
 - Protocol parsing is inspired by [aiostomp](https://github.com/pedrokiefer/aiostomp/blob/3449dcb53f43e5956ccc7662bb5b7d76bc6ef36b/aiostomp/protocol.py) (meaning: consumed by me and refactored from).
 - stompman is tested and used with [ActiveMQ Artemis](https://activemq.apache.org/components/artemis/) and [ActiveMQ Classic](https://activemq.apache.org/components/classic/).
+    - Caveat: a message sent by a Stomp client is converted into a JMS `TextMessage`/`BytesMessage` based on the `content-length` header (see the docs [here](https://activemq.apache.org/components/classic/documentation/stomp)). In order to send a `TextMessage`, `Client.send` needs to be invoked with `add_content_length` header set to `False` 
 - Specification says that headers in CONNECT and CONNECTED frames shouldn't be escaped for backwards compatibility. stompman escapes headers in CONNECT frame (outcoming), but does not unescape headers in CONNECTED (outcoming).
 
 ### FastStream STOMP broker

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -115,11 +115,22 @@ class Client:
                         pass
 
     async def send(
-        self, body: bytes, destination: str, *, content_type: str | None = None, headers: dict[str, str] | None = None
+        self,
+        body: bytes,
+        destination: str,
+        *,
+        content_type: str | None = None,
+        add_content_length: bool = True,
+        headers: dict[str, str] | None = None,
     ) -> None:
         await self._connection_manager.write_frame_reconnecting(
             SendFrame.build(
-                body=body, destination=destination, transaction=None, content_type=content_type, headers=headers
+                body=body,
+                destination=destination,
+                transaction=None,
+                content_type=content_type,
+                add_content_length=add_content_length,
+                headers=headers,
             )
         )
 

--- a/packages/stompman/stompman/frames.py
+++ b/packages/stompman/stompman/frames.py
@@ -149,11 +149,13 @@ class SendFrame:
         destination: str,
         transaction: str | None,
         content_type: str | None,
+        add_content_length: bool,
         headers: dict[str, str] | None,
     ) -> Self:
         all_headers: SendHeaders = headers or {}  # type: ignore[assignment]
         all_headers["destination"] = destination
-        all_headers["content-length"] = str(len(body))
+        if add_content_length:
+            all_headers["content-length"] = str(len(body))
         if content_type is not None:
             all_headers["content-type"] = content_type
         if transaction is not None:

--- a/packages/stompman/stompman/transaction.py
+++ b/packages/stompman/stompman/transaction.py
@@ -34,10 +34,21 @@ class Transaction:
                 self._active_transactions.remove(self)
 
     async def send(
-        self, body: bytes, destination: str, *, content_type: str | None = None, headers: dict[str, str] | None = None
+        self,
+        body: bytes,
+        destination: str,
+        *,
+        content_type: str | None = None,
+        add_content_length: bool = True,
+        headers: dict[str, str] | None = None,
     ) -> None:
         frame = SendFrame.build(
-            body=body, destination=destination, transaction=self.id, content_type=content_type, headers=headers
+            body=body,
+            destination=destination,
+            transaction=self.id,
+            content_type=content_type,
+            add_content_length=add_content_length,
+            headers=headers,
         )
         self.sent_frames.append(frame)
         await self._connection_manager.write_frame_reconnecting(frame)

--- a/packages/stompman/test_stompman/test_send.py
+++ b/packages/stompman/test_stompman/test_send.py
@@ -1,0 +1,55 @@
+import asyncio
+from typing import Any
+
+import faker
+import pytest
+from stompman import (
+    SendFrame,
+)
+from stompman.frames import SendHeaders
+
+from test_stompman.conftest import (
+    EnrichedClient,
+    create_spying_connection,
+    enrich_expected_frames,
+    get_read_frames_with_lifespan,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_body", "expected_headers"),
+    [
+        (
+            {"body": b"Some body", "destination": "Some/queue"},
+            b"Some body",
+            {"content-length": "9", "destination": "Some/queue"},
+        ),
+        (
+            {"body": b"Some body", "destination": "Some/queue", "add_content_length": True},
+            b"Some body",
+            {"content-length": "9", "destination": "Some/queue"},
+        ),
+        (
+            {"body": b"Some body", "destination": "Some/queue", "content_type": "text/plain"},
+            b"Some body",
+            {"content-length": "9", "destination": "Some/queue", "content-type": "text/plain"},
+        ),
+        (
+            {"body": b"Some body", "destination": "Some/queue", "add_content_length": False},
+            b"Some body",
+            {"destination": "Some/queue"},
+        ),
+    ],
+)
+async def test_send_message(args: dict[str, Any], expected_body: bytes, expected_headers: SendHeaders) -> None:
+    connection_class, collected_frames = create_spying_connection(*get_read_frames_with_lifespan([]))
+
+    async with EnrichedClient(connection_class=connection_class) as client:
+        await client.send(**args)
+        await asyncio.sleep(0)
+
+    assert collected_frames == enrich_expected_frames(
+        SendFrame(headers=expected_headers, body=expected_body),
+    )


### PR DESCRIPTION
Added add_content_length parameter; if set to False, SEND frames won’t have the content-length header set and ActiveMQ will translate them to text messages for JMS clients