### PR TITLE
Add support for custom connect headers

### DIFF
--- a/packages/stompman/stompman/config.py
+++ b/packages/stompman/stompman/config.py
@@ -31,6 +31,7 @@ class ConnectionParameters:
     login: str
     passcode: str = field(repr=False)
     ws_uri_path: str | None = None
+    connect_headers: dict[str, str] = field(default_factory=dict, repr=False)
 
     @property
     def unescaped_passcode(self) -> str:

--- a/packages/stompman/stompman/connection_lifespan.py
+++ b/packages/stompman/stompman/connection_lifespan.py
@@ -2,7 +2,7 @@ import asyncio
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 from uuid import uuid4
 
 from stompman.config import ConnectionParameters, Heartbeat
@@ -11,6 +11,7 @@ from stompman.errors import ConnectionConfirmationTimeout, StompProtocolConnecti
 from stompman.frames import (
     ConnectedFrame,
     ConnectFrame,
+    ConnectHeaders,
     DisconnectFrame,
     ReceiptFrame,
 )
@@ -47,18 +48,18 @@ class ConnectionLifespan(AbstractConnectionLifespan):
     set_heartbeat_interval: Callable[[Heartbeat], Any]
 
     async def _establish_connection(self) -> EstablishedConnectionResult | StompProtocolConnectionIssue:
-        await self.connection.write_frame(
-            ConnectFrame(
-                headers={
-                    **self.connection_parameters.connect_headers,
-                    "accept-version": self.protocol_version,
-                    "heart-beat": self.client_heartbeat.to_header(),
-                    "host": self.connection_parameters.host,
-                    "login": self.connection_parameters.login,
-                    "passcode": self.connection_parameters.unescaped_passcode,
-                },
-            )
+        connect_headers = cast(
+            "ConnectHeaders",
+            self.connection_parameters.connect_headers
+            | {
+                "accept-version": self.protocol_version,
+                "heart-beat": self.client_heartbeat.to_header(),
+                "host": self.connection_parameters.host,
+                "login": self.connection_parameters.login,
+                "passcode": self.connection_parameters.unescaped_passcode,
+            },
         )
+        await self.connection.write_frame(ConnectFrame(headers=connect_headers))
         collected_frames = []
 
         async def take_connected_frame_and_collect_other_frames() -> ConnectedFrame:

--- a/packages/stompman/stompman/connection_lifespan.py
+++ b/packages/stompman/stompman/connection_lifespan.py
@@ -2,7 +2,7 @@ import asyncio
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any, Protocol, cast
+from typing import Any, Protocol
 from uuid import uuid4
 
 from stompman.config import ConnectionParameters, Heartbeat
@@ -11,7 +11,6 @@ from stompman.errors import ConnectionConfirmationTimeout, StompProtocolConnecti
 from stompman.frames import (
     ConnectedFrame,
     ConnectFrame,
-    ConnectHeaders,
     DisconnectFrame,
     ReceiptFrame,
 )
@@ -50,17 +49,14 @@ class ConnectionLifespan(AbstractConnectionLifespan):
     async def _establish_connection(self) -> EstablishedConnectionResult | StompProtocolConnectionIssue:
         await self.connection.write_frame(
             ConnectFrame(
-                headers=cast(
-                    ConnectHeaders,
-                    {
-                        **self.connection_parameters.connect_headers,
-                        "accept-version": self.protocol_version,
-                        "heart-beat": self.client_heartbeat.to_header(),
-                        "host": self.connection_parameters.host,
-                        "login": self.connection_parameters.login,
-                        "passcode": self.connection_parameters.unescaped_passcode,
-                    },
-                ),
+                headers={
+                    **self.connection_parameters.connect_headers,
+                    "accept-version": self.protocol_version,
+                    "heart-beat": self.client_heartbeat.to_header(),
+                    "host": self.connection_parameters.host,
+                    "login": self.connection_parameters.login,
+                    "passcode": self.connection_parameters.unescaped_passcode,
+                },
             )
         )
         collected_frames = []

--- a/packages/stompman/stompman/connection_lifespan.py
+++ b/packages/stompman/stompman/connection_lifespan.py
@@ -2,7 +2,7 @@ import asyncio
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 from uuid import uuid4
 
 from stompman.config import ConnectionParameters, Heartbeat
@@ -11,6 +11,7 @@ from stompman.errors import ConnectionConfirmationTimeout, StompProtocolConnecti
 from stompman.frames import (
     ConnectedFrame,
     ConnectFrame,
+    ConnectHeaders,
     DisconnectFrame,
     ReceiptFrame,
 )
@@ -49,13 +50,17 @@ class ConnectionLifespan(AbstractConnectionLifespan):
     async def _establish_connection(self) -> EstablishedConnectionResult | StompProtocolConnectionIssue:
         await self.connection.write_frame(
             ConnectFrame(
-                headers={
-                    "accept-version": self.protocol_version,
-                    "heart-beat": self.client_heartbeat.to_header(),
-                    "host": self.connection_parameters.host,
-                    "login": self.connection_parameters.login,
-                    "passcode": self.connection_parameters.unescaped_passcode,
-                },
+                headers=cast(
+                    ConnectHeaders,
+                    {
+                        **self.connection_parameters.connect_headers,
+                        "accept-version": self.protocol_version,
+                        "heart-beat": self.client_heartbeat.to_header(),
+                        "host": self.connection_parameters.host,
+                        "login": self.connection_parameters.login,
+                        "passcode": self.connection_parameters.unescaped_passcode,
+                    },
+                ),
             )
         )
         collected_frames = []

--- a/packages/stompman/stompman/frames.py
+++ b/packages/stompman/stompman/frames.py
@@ -1,7 +1,17 @@
 from dataclasses import dataclass
-from typing import Literal, NotRequired, Self, TypeAlias, TypedDict
+from typing import Literal, NotRequired, Self, TypedDict
 
-ConnectHeaders: TypeAlias = dict[str, str]
+ConnectHeaders = TypedDict(
+    "ConnectHeaders",
+    {
+        "accept-version": str,
+        "host": str,
+        "login": NotRequired[str],
+        "passcode": NotRequired[str],
+        "heart-beat": NotRequired[str],
+        "content-length": NotRequired[str],
+    },
+)
 ConnectedHeaders = TypedDict(
     "ConnectedHeaders",
     {

--- a/packages/stompman/stompman/frames.py
+++ b/packages/stompman/stompman/frames.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from typing import Literal, NotRequired, Self, TypedDict
+from typing import Literal, NotRequired, Self, TypeAlias, TypedDict
 
-ConnectHeaders = dict[str, str]
+ConnectHeaders: TypeAlias = dict[str, str]
 ConnectedHeaders = TypedDict(
     "ConnectedHeaders",
     {

--- a/packages/stompman/stompman/frames.py
+++ b/packages/stompman/stompman/frames.py
@@ -1,17 +1,7 @@
 from dataclasses import dataclass
 from typing import Literal, NotRequired, Self, TypedDict
 
-ConnectHeaders = TypedDict(
-    "ConnectHeaders",
-    {
-        "accept-version": str,
-        "host": str,
-        "login": NotRequired[str],
-        "passcode": NotRequired[str],
-        "heart-beat": NotRequired[str],
-        "content-length": NotRequired[str],
-    },
-)
+ConnectHeaders = dict[str, str]
 ConnectedHeaders = TypedDict(
     "ConnectedHeaders",
     {

--- a/packages/stompman/test_stompman/test_connection_lifespan.py
+++ b/packages/stompman/test_stompman/test_connection_lifespan.py
@@ -57,6 +57,28 @@ async def test_client_connection_lifespan_ok(monkeypatch: pytest.MonkeyPatch, fa
     assert collected_frames == [connect_frame, connected_frame, disconnect_frame, receipt_frame]
 
 
+async def test_client_connection_lifespan_adds_custom_connect_headers() -> None:
+    connected_frame = build_dataclass(ConnectedFrame, headers={"version": Client.PROTOCOL_VERSION, "heart-beat": "1,1"})
+    connection_class, collected_frames = create_spying_connection([connected_frame], [], [build_dataclass(ReceiptFrame)])
+
+    async with EnrichedClient(
+        [
+            ConnectionParameters(
+                "localhost",
+                10,
+                "login",
+                "passcode",
+                connect_headers={"client-id": "client-1"},
+            )
+        ],
+        connection_class=connection_class,
+    ):
+        await asyncio.sleep(0)
+
+    assert isinstance(collected_frames[0], ConnectFrame)
+    assert collected_frames[0].headers["client-id"] == "client-1"
+
+
 @pytest.mark.usefixtures("mock_sleep")
 async def test_client_connection_lifespan_connection_not_confirmed(
     monkeypatch: pytest.MonkeyPatch, faker: faker.Faker

--- a/packages/stompman/test_stompman/test_connection_lifespan.py
+++ b/packages/stompman/test_stompman/test_connection_lifespan.py
@@ -58,8 +58,13 @@ async def test_client_connection_lifespan_ok(monkeypatch: pytest.MonkeyPatch, fa
 
 
 async def test_client_connection_lifespan_adds_custom_connect_headers() -> None:
-    connected_frame = build_dataclass(ConnectedFrame, headers={"version": Client.PROTOCOL_VERSION, "heart-beat": "1,1"})
-    connection_class, collected_frames = create_spying_connection([connected_frame], [], [build_dataclass(ReceiptFrame)])
+    connected_frame = build_dataclass(
+        ConnectedFrame,
+        headers={"version": Client.PROTOCOL_VERSION, "heart-beat": "1,1"},
+    )
+    connection_class, collected_frames = create_spying_connection(
+        [connected_frame], [], [build_dataclass(ReceiptFrame)]
+    )
 
     async with EnrichedClient(
         [
@@ -75,8 +80,9 @@ async def test_client_connection_lifespan_adds_custom_connect_headers() -> None:
     ):
         await asyncio.sleep(0)
 
-    assert isinstance(collected_frames[0], ConnectFrame)
-    assert collected_frames[0].headers["client-id"] == "client-1"
+    connect_frame = collected_frames[0]
+    assert isinstance(connect_frame, ConnectFrame)
+    assert connect_frame.headers["client-id"] == "client-1"
 
 
 @pytest.mark.usefixtures("mock_sleep")

--- a/packages/stompman/test_stompman/test_connection_lifespan.py
+++ b/packages/stompman/test_stompman/test_connection_lifespan.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import AsyncGenerator, Coroutine
-from typing import Any
+from typing import Any, cast
 from unittest import mock
 
 import faker
@@ -82,7 +82,7 @@ async def test_client_connection_lifespan_adds_custom_connect_headers() -> None:
 
     connect_frame = collected_frames[0]
     assert isinstance(connect_frame, ConnectFrame)
-    assert connect_frame.headers["client-id"] == "client-1"
+    assert cast("dict[str, str]", connect_frame.headers)["client-id"] == "client-1"
 
 
 @pytest.mark.usefixtures("mock_sleep")


### PR DESCRIPTION
Closes #190.

## Summary
- add `connect_headers` to `ConnectionParameters`
- include custom headers when creating the STOMP `ConnectFrame`
- add coverage for passing a `client-id` header during connection
