### PR TITLE
Fix stuck faststream-stomp consumers (ping=True but no progress)

### DIFF
--- a/packages/faststream-stomp/faststream_stomp/broker.py
+++ b/packages/faststream-stomp/faststream_stomp/broker.py
@@ -41,6 +41,7 @@ class StompSecurity(BaseSecurity):
 
 
 def _handle_listen_task_done(listen_task: asyncio.Task[None]) -> None:
+    # Not sure how to test this. See https://github.com/community-of-python/stompman/pull/117#issuecomment-2983584449.
     try:
         task_exception = listen_task.exception()
     except asyncio.CancelledError:

--- a/packages/faststream-stomp/faststream_stomp/broker.py
+++ b/packages/faststream-stomp/faststream_stomp/broker.py
@@ -52,9 +52,7 @@ def _handle_listen_task_done(listen_task: asyncio.Task[None]) -> None:
         stompman.FailedAllConnectAttemptsError,
     ):
         raise SystemExit(1)
-    logging.getLogger("faststream.stomp").error(
-        "listen task exited with unhandled exception", exc_info=task_exception
-    )
+    logging.getLogger("faststream.stomp").error("listen task exited with unhandled exception", exc_info=task_exception)
 
 
 class StompParamsStorage(DefaultLoggerStorage):

--- a/packages/faststream-stomp/faststream_stomp/broker.py
+++ b/packages/faststream-stomp/faststream_stomp/broker.py
@@ -41,16 +41,20 @@ class StompSecurity(BaseSecurity):
 
 
 def _handle_listen_task_done(listen_task: asyncio.Task[None]) -> None:
-    # Not sure how to test this. See https://github.com/community-of-python/stompman/pull/117#issuecomment-2983584449.
     try:
         task_exception = listen_task.exception()
     except asyncio.CancelledError:
+        return
+    if task_exception is None:
         return
     if isinstance(task_exception, ExceptionGroup) and isinstance(
         task_exception.exceptions[0],
         stompman.FailedAllConnectAttemptsError,
     ):
         raise SystemExit(1)
+    logging.getLogger("faststream.stomp").error(
+        "listen task exited with unhandled exception", exc_info=task_exception
+    )
 
 
 class StompParamsStorage(DefaultLoggerStorage):

--- a/packages/faststream-stomp/test_faststream_stomp/test_main.py
+++ b/packages/faststream-stomp/test_faststream_stomp/test_main.py
@@ -1,3 +1,6 @@
+import asyncio
+import contextlib
+import logging
 import typing
 
 import faker
@@ -159,3 +162,27 @@ async def test_prometheus_publish(faker: faker.Faker, broker: faststream_stomp.S
     async with faststream_stomp.TestStompBroker(broker):
         await broker.start()
         await broker.publish(faker.pystr(), destination, correlation_id=gen_cor_id())
+
+
+def test_handle_listen_task_done_logs_unhandled_exception(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    from faststream_stomp.broker import _handle_listen_task_done
+
+    # faststream parent logger has propagate=False, which would block caplog (attached to root)
+    monkeypatch.setattr(logging.getLogger("faststream"), "propagate", True)
+
+    async def run() -> None:
+        async def boom() -> None:
+            raise RuntimeError("kaboom")
+
+        task: asyncio.Task[None] = asyncio.create_task(boom())
+        with contextlib.suppress(RuntimeError):
+            await task
+
+        with caplog.at_level(logging.ERROR):
+            _handle_listen_task_done(task)
+
+    asyncio.run(run())
+
+    assert any("listen task exited" in m.lower() for m in caplog.messages)

--- a/packages/faststream-stomp/test_faststream_stomp/test_main.py
+++ b/packages/faststream-stomp/test_faststream_stomp/test_main.py
@@ -10,6 +10,7 @@ import pytest
 import stompman
 from faststream import FastStream
 from faststream.message import gen_cor_id
+from faststream_stomp.broker import _handle_listen_task_done
 from faststream_stomp.opentelemetry import StompTelemetryMiddleware
 from faststream_stomp.prometheus import StompPrometheusMiddleware
 from faststream_stomp.router import StompRouter
@@ -167,14 +168,13 @@ async def test_prometheus_publish(faker: faker.Faker, broker: faststream_stomp.S
 def test_handle_listen_task_done_logs_unhandled_exception(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    from faststream_stomp.broker import _handle_listen_task_done
-
     # faststream parent logger has propagate=False, which would block caplog (attached to root)
     monkeypatch.setattr(logging.getLogger("faststream"), "propagate", True)
 
     async def run() -> None:
-        async def boom() -> None:
-            raise RuntimeError("kaboom")
+        async def boom() -> None:  # noqa: RUF029
+            msg = "kaboom"
+            raise RuntimeError(msg)
 
         task: asyncio.Task[None] = asyncio.create_task(boom())
         with contextlib.suppress(RuntimeError):

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -141,7 +141,11 @@ class Client:
                             task = task_group.create_task(_run_handler_with_safety_net(handler_coro))
                             if self._handler_semaphore is not None:
                                 semaphore = self._handler_semaphore
-                                task.add_done_callback(lambda _t, s=semaphore: s.release())
+
+                                def _release(_t: asyncio.Task[None], s: asyncio.Semaphore = semaphore) -> None:
+                                    s.release()
+
+                                task.add_done_callback(_release)
                     case ErrorFrame():
                         if self.on_error_frame:
                             self.on_error_frame(frame)

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -30,9 +30,7 @@ from stompman.transaction import Transaction
 async def _run_handler_with_safety_net(coro: Coroutine[Any, Any, Any]) -> None:
     try:
         await coro
-    except asyncio.CancelledError:
-        raise
-    except BaseException:  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         LOGGER.exception("unhandled exception in message handler")
 
 

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -56,8 +56,8 @@ class Client:
     """Client will check if server alive `server heartbeat interval` times `interval factor`"""
     no_message_restart_interval: timedelta | None = timedelta(hours=1)
     """Force reconnect if no messages received within this interval. None to disable."""
-    max_concurrent_handlers: int | None = None
-    """Cap on concurrently-running message handlers. None means unbounded (current behavior)."""
+    max_concurrent_handlers: int | None = 100
+    """Cap on concurrently-running message handlers. Set to None to disable the cap."""
 
     connection_class: type[AbstractConnection] = Connection
 

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -208,6 +208,8 @@ class Client:
         return subscription
 
     def is_alive(self) -> bool:
+        if self._listen_task.done():
+            return False
         return (
             self._connection_manager._active_connection_state or False
         ) and self._connection_manager._active_connection_state.is_alive(self.check_server_alive_interval_factor)

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -27,6 +27,15 @@ from stompman.subscription import AckableMessageFrame, ActiveSubscriptions, Auto
 from stompman.transaction import Transaction
 
 
+async def _run_handler_with_safety_net(coro: Coroutine[Any, Any, Any]) -> None:
+    try:
+        await coro
+    except asyncio.CancelledError:
+        raise
+    except BaseException:  # noqa: BLE001
+        LOGGER.exception("unhandled exception in message handler")
+
+
 @dataclass(kw_only=True, slots=True)
 class Client:
     PROTOCOL_VERSION: ClassVar = "1.2"  # https://stomp.github.io/stomp-specification-1.2.html
@@ -107,7 +116,7 @@ class Client:
                         self._connection_manager._last_message_received_time = time.time()
                         received_at_reconnection_count = epoch
                         if subscription := self._active_subscriptions.get_by_id(frame.headers["subscription"]):
-                            task_group.create_task(
+                            handler_coro = (
                                 subscription._run_handler(
                                     frame=frame,
                                     received_at_reconnection_count=received_at_reconnection_count,
@@ -122,6 +131,7 @@ class Client:
                                     )
                                 )
                             )
+                            task_group.create_task(_run_handler_with_safety_net(handler_coro))
                     case ErrorFrame():
                         if self.on_error_frame:
                             self.on_error_frame(frame)

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -58,6 +58,8 @@ class Client:
     """Client will check if server alive `server heartbeat interval` times `interval factor`"""
     no_message_restart_interval: timedelta | None = timedelta(hours=1)
     """Force reconnect if no messages received within this interval. None to disable."""
+    max_concurrent_handlers: int | None = None
+    """Cap on concurrently-running message handlers. None means unbounded (current behavior)."""
 
     connection_class: type[AbstractConnection] = Connection
 
@@ -67,6 +69,7 @@ class Client:
     _exit_stack: AsyncExitStack = field(default_factory=AsyncExitStack, init=False)
     _listen_task: asyncio.Task[None] = field(init=False, repr=False)
     _task_group: asyncio.TaskGroup = field(init=False, repr=False)
+    _handler_semaphore: asyncio.Semaphore | None = field(init=False, default=None, repr=False)
 
     def __post_init__(self) -> None:
         self._connection_manager = ConnectionManager(
@@ -90,6 +93,8 @@ class Client:
             no_message_restart_interval=self.no_message_restart_interval,
             ssl=self.ssl,
         )
+        if self.max_concurrent_handlers is not None:
+            self._handler_semaphore = asyncio.Semaphore(self.max_concurrent_handlers)
 
     async def __aenter__(self) -> Self:
         self._task_group = await self._exit_stack.enter_async_context(asyncio.TaskGroup())
@@ -116,6 +121,8 @@ class Client:
                         self._connection_manager._last_message_received_time = time.time()
                         received_at_reconnection_count = epoch
                         if subscription := self._active_subscriptions.get_by_id(frame.headers["subscription"]):
+                            if self._handler_semaphore is not None:
+                                await self._handler_semaphore.acquire()
                             handler_coro = (
                                 subscription._run_handler(
                                     frame=frame,
@@ -131,7 +138,10 @@ class Client:
                                     )
                                 )
                             )
-                            task_group.create_task(_run_handler_with_safety_net(handler_coro))
+                            task = task_group.create_task(_run_handler_with_safety_net(handler_coro))
+                            if self._handler_semaphore is not None:
+                                semaphore = self._handler_semaphore
+                                task.add_done_callback(lambda _t, s=semaphore: s.release())
                     case ErrorFrame():
                         if self.on_error_frame:
                             self.on_error_frame(frame)

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -32,9 +32,7 @@ class ActiveConnectionState:
     connected_at: float
 
     def is_alive(self, check_server_alive_interval_factor: int) -> bool:
-        threshold_seconds = (
-            self.server_heartbeat.will_send_interval_ms / 1000 * check_server_alive_interval_factor
-        )
+        threshold_seconds = self.server_heartbeat.will_send_interval_ms / 1000 * check_server_alive_interval_factor
         now = time.time()
         if (last_read_time := self.connection.last_read_time) is None:
             return (now - self.connected_at) < threshold_seconds

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -32,12 +32,13 @@ class ActiveConnectionState:
     connected_at: float
 
     def is_alive(self, check_server_alive_interval_factor: int) -> bool:
-        if not (last_read_time := self.connection.last_read_time):
-            return True
-
-        return (self.server_heartbeat.will_send_interval_ms / 1000 * check_server_alive_interval_factor) > (
-            time.time() - last_read_time
+        threshold_seconds = (
+            self.server_heartbeat.will_send_interval_ms / 1000 * check_server_alive_interval_factor
         )
+        now = time.time()
+        if (last_read_time := self.connection.last_read_time) is None:
+            return (now - self.connected_at) < threshold_seconds
+        return (now - last_read_time) < threshold_seconds
 
 
 @dataclass(kw_only=True, slots=True)

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -17,7 +17,7 @@ from stompman.errors import (
     FailedAllConnectAttemptsError,
     FailedAllWriteAttemptsError,
 )
-from stompman.frames import AnyClientFrame, AnyServerFrame
+from stompman.frames import AckFrame, AnyClientFrame, AnyServerFrame, NackFrame
 from stompman.logger import LOGGER
 
 if TYPE_CHECKING:
@@ -39,6 +39,15 @@ class ActiveConnectionState:
         if (last_read_time := self.connection.last_read_time) is None:
             return (now - self.connected_at) < threshold_seconds
         return (now - last_read_time) < threshold_seconds
+
+
+def _log_dropped_frame(frame: AnyClientFrame, *, reason: str) -> None:
+    if isinstance(frame, NackFrame):
+        LOGGER.error("dropping NACK: %s. headers=%s", reason, frame.headers)
+    elif isinstance(frame, AckFrame):
+        LOGGER.warning("dropping ACK: %s. headers=%s", reason, frame.headers)
+    else:
+        LOGGER.info("dropping %s: %s", type(frame).__name__, reason)
 
 
 @dataclass(kw_only=True, slots=True)
@@ -248,10 +257,12 @@ class ConnectionManager:
 
     async def maybe_write_frame(self, frame: AnyClientFrame) -> bool:
         if not self._active_connection_state:
+            _log_dropped_frame(frame, reason="no active connection")
             return False
         try:
             await self._active_connection_state.connection.write_frame(frame)
         except ConnectionLostError as error:
+            _log_dropped_frame(frame, reason="connection lost mid-write")
             self._clear_active_connection_state(error)
             return False
         return True

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -29,6 +29,7 @@ class ActiveConnectionState:
     connection: AbstractConnection
     lifespan: "AbstractConnectionLifespan"
     server_heartbeat: Heartbeat
+    connected_at: float
 
     def is_alive(self, check_server_alive_interval_factor: int) -> bool:
         if not (last_read_time := self.connection.last_read_time):
@@ -165,7 +166,10 @@ class ConnectionManager:
 
         return (
             ActiveConnectionState(
-                connection=connection, lifespan=lifespan, server_heartbeat=connection_result.server_heartbeat
+                connection=connection,
+                lifespan=lifespan,
+                server_heartbeat=connection_result.server_heartbeat,
+                connected_at=time.time(),
             )
             if isinstance(connection_result, EstablishedConnectionResult)
             else connection_result

--- a/packages/stompman/stompman/subscription.py
+++ b/packages/stompman/stompman/subscription.py
@@ -92,7 +92,7 @@ class BaseSubscription:
             )
             return
         if received_at_reconnection_count != self._connection_manager._reconnection_count:
-            LOGGER.debug(
+            LOGGER.error(
                 "skipping nack for message frame: connection changed since message was received. "
                 "message_id: %s, subscription_id: %s, received_at_reconnection_count: %s, "
                 "current_reconnection_count: %s",
@@ -124,7 +124,7 @@ class BaseSubscription:
             )
             return
         if received_at_reconnection_count != self._connection_manager._reconnection_count:
-            LOGGER.debug(
+            LOGGER.warning(
                 "skipping ack for message frame: connection changed since message was received. "
                 "message_id: %s, subscription_id: %s, received_at_reconnection_count: %s, "
                 "current_reconnection_count: %s",

--- a/packages/stompman/test_stompman/test_aliveness.py
+++ b/packages/stompman/test_stompman/test_aliveness.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 
 import pytest
@@ -41,3 +42,23 @@ async def test_is_alive_false_after_grace_when_last_read_time_is_none(
     # past grace window (heartbeat 1000ms * factor 3 = 3s) → False
     monkeypatch.setattr(time, "time", lambda: state.connected_at + 10.0)
     assert client.is_alive() is False
+
+
+async def test_is_alive_false_when_listen_task_dead(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection_class, _ = create_spying_connection(
+        [ConnectedFrame(headers={"version": Client.PROTOCOL_VERSION, "heart-beat": "1000,1000"})],
+        [],
+        [build_dataclass(ReceiptFrame)],
+    )
+    client = await EnrichedClient(connection_class=connection_class).__aenter__()
+    state = client._connection_manager._active_connection_state
+    assert state is not None
+    state.connection.last_read_time = time.time()  # connection is fine
+
+    # simulate listen task finishing with an unhandled exception
+    fake_task: asyncio.Task[None] = asyncio.create_task(asyncio.sleep(0))
+    await fake_task
+    monkeypatch.setattr(client, "_listen_task", fake_task)  # done, no exception
+    assert client.is_alive() is False, "listener done means not alive"

--- a/packages/stompman/test_stompman/test_aliveness.py
+++ b/packages/stompman/test_stompman/test_aliveness.py
@@ -19,3 +19,25 @@ async def test_connection_alive(is_alive: bool) -> None:  # noqa: FBT001
     assert client._connection_manager._active_connection_state
     client._connection_manager._active_connection_state.connection.last_read_time = time.time() if is_alive else 10
     assert client.is_alive() == is_alive
+
+
+async def test_is_alive_false_after_grace_when_last_read_time_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection_class, _ = create_spying_connection(
+        [ConnectedFrame(headers={"version": Client.PROTOCOL_VERSION, "heart-beat": "1000,1000"})],
+        [],
+        [build_dataclass(ReceiptFrame)],
+    )
+    client = await EnrichedClient(connection_class=connection_class).__aenter__()
+    state = client._connection_manager._active_connection_state
+    assert state is not None
+    state.connection.last_read_time = None  # simulate a connection that has not yet read
+
+    # within grace window → True
+    monkeypatch.setattr(time, "time", lambda: state.connected_at + 1.0)
+    assert client.is_alive() is True
+
+    # past grace window (heartbeat 1000ms * factor 3 = 3s) → False
+    monkeypatch.setattr(time, "time", lambda: state.connected_at + 10.0)
+    assert client.is_alive() is False

--- a/packages/stompman/test_stompman/test_connection_manager.py
+++ b/packages/stompman/test_stompman/test_connection_manager.py
@@ -431,10 +431,7 @@ async def test_maybe_write_frame_logs_dropped_nack_at_error(
     with caplog.at_level(logging.ERROR, logger="stompman"):
         wrote = await manager.maybe_write_frame(stompman.NackFrame(headers={"id": "a", "subscription": "s"}))
     assert wrote is False
-    assert any(
-        r.levelno == logging.ERROR and "dropping nack" in r.message.lower()
-        for r in caplog.records
-    )
+    assert any(r.levelno == logging.ERROR and "dropping nack" in r.message.lower() for r in caplog.records)
 
 
 async def test_maybe_write_frame_logs_dropped_ack_at_warning(
@@ -444,10 +441,7 @@ async def test_maybe_write_frame_logs_dropped_ack_at_warning(
     with caplog.at_level(logging.WARNING, logger="stompman"):
         wrote = await manager.maybe_write_frame(stompman.AckFrame(headers={"id": "a", "subscription": "s"}))
     assert wrote is False
-    assert any(
-        r.levelno == logging.WARNING and "dropping ack" in r.message.lower()
-        for r in caplog.records
-    )
+    assert any(r.levelno == logging.WARNING and "dropping ack" in r.message.lower() for r in caplog.records)
 
 
 async def test_maybe_write_frame_logs_dropped_unsubscribe_at_info(
@@ -457,7 +451,4 @@ async def test_maybe_write_frame_logs_dropped_unsubscribe_at_info(
     with caplog.at_level(logging.INFO, logger="stompman"):
         wrote = await manager.maybe_write_frame(stompman.UnsubscribeFrame(headers={"id": "s"}))
     assert wrote is False
-    assert any(
-        r.levelno == logging.INFO and "dropping unsubscribeframe" in r.message.lower()
-        for r in caplog.records
-    )
+    assert any(r.levelno == logging.INFO and "dropping unsubscribeframe" in r.message.lower() for r in caplog.records)

--- a/packages/stompman/test_stompman/test_connection_manager.py
+++ b/packages/stompman/test_stompman/test_connection_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import time
 from collections.abc import AsyncGenerator, AsyncIterable
 from datetime import timedelta
@@ -7,6 +8,7 @@ from typing import Literal, Self
 from unittest import mock
 
 import pytest
+import stompman
 from stompman import (
     AnyServerFrame,
     ConnectedFrame,
@@ -419,3 +421,43 @@ async def test_no_message_restart_disabled(monkeypatch: pytest.MonkeyPatch) -> N
         for _ in range(10):
             await asyncio.sleep(0)
         assert manager._reconnection_count == 0
+
+
+async def test_maybe_write_frame_logs_dropped_nack_at_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = EnrichedConnectionManager(connection_class=BaseMockConnection)
+    # no active connection state -> drop path 1
+    with caplog.at_level(logging.ERROR, logger="stompman"):
+        wrote = await manager.maybe_write_frame(stompman.NackFrame(headers={"id": "a", "subscription": "s"}))
+    assert wrote is False
+    assert any(
+        r.levelno == logging.ERROR and "dropping nack" in r.message.lower()
+        for r in caplog.records
+    )
+
+
+async def test_maybe_write_frame_logs_dropped_ack_at_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = EnrichedConnectionManager(connection_class=BaseMockConnection)
+    with caplog.at_level(logging.WARNING, logger="stompman"):
+        wrote = await manager.maybe_write_frame(stompman.AckFrame(headers={"id": "a", "subscription": "s"}))
+    assert wrote is False
+    assert any(
+        r.levelno == logging.WARNING and "dropping ack" in r.message.lower()
+        for r in caplog.records
+    )
+
+
+async def test_maybe_write_frame_logs_dropped_unsubscribe_at_info(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = EnrichedConnectionManager(connection_class=BaseMockConnection)
+    with caplog.at_level(logging.INFO, logger="stompman"):
+        wrote = await manager.maybe_write_frame(stompman.UnsubscribeFrame(headers={"id": "s"}))
+    assert wrote is False
+    assert any(
+        r.levelno == logging.INFO and "dropping unsubscribeframe" in r.message.lower()
+        for r in caplog.records
+    )

--- a/packages/stompman/test_stompman/test_connection_manager.py
+++ b/packages/stompman/test_stompman/test_connection_manager.py
@@ -202,7 +202,10 @@ async def test_get_active_connection_state_ok_concurrent() -> None:
         == third_state
         == fourth_state
         == ActiveConnectionState(
-            connection=BaseMockConnection(), lifespan=lifespan_factory.return_value, server_heartbeat=server_heartbeat
+            connection=BaseMockConnection(),
+            lifespan=lifespan_factory.return_value,
+            server_heartbeat=server_heartbeat,
+            connected_at=first_state.connected_at,
         )
     )
     assert first_state is second_state is third_state is fourth_state

--- a/packages/stompman/test_stompman/test_subscription.py
+++ b/packages/stompman/test_stompman/test_subscription.py
@@ -551,7 +551,9 @@ async def test_auto_ack_handler_unhandled_exception_does_not_kill_listener(
 
     handled: list[str] = []
 
-    async def handler(frame: MessageFrame) -> None:
+    expected_handled = 2
+
+    async def handler(frame: MessageFrame) -> None:  # noqa: RUF029
         handled.append(frame.headers["message-id"])
         if frame.headers["message-id"] == "a":
             raise Boom
@@ -570,7 +572,7 @@ async def test_auto_ack_handler_unhandled_exception_does_not_kill_listener(
             )
             for _ in range(20):
                 await asyncio.sleep(0)
-                if len(handled) == 2:
+                if len(handled) == expected_handled:
                     break
             await subscription.unsubscribe()
 
@@ -594,11 +596,13 @@ async def test_manual_ack_handler_unhandled_exception_does_not_kill_listener(
     )
 
     handled: list[str] = []
+    expected_handled = 2
 
-    async def handler(frame: stompman.subscription.AckableMessageFrame) -> None:
+    async def handler(frame: stompman.subscription.AckableMessageFrame) -> None:  # noqa: RUF029
         handled.append(frame.headers["message-id"])
         if frame.headers["message-id"] == "a":
-            raise RuntimeError("boom")
+            msg = "boom"
+            raise RuntimeError(msg)
 
     connection_class, _ = create_spying_connection(*get_read_frames_with_lifespan([message_a, message_b]))
 
@@ -607,7 +611,7 @@ async def test_manual_ack_handler_unhandled_exception_does_not_kill_listener(
             subscription = await client.subscribe_with_manual_ack(destination, handler)
             for _ in range(20):
                 await asyncio.sleep(0)
-                if len(handled) == 2:
+                if len(handled) == expected_handled:
                     break
             await subscription.unsubscribe()
 
@@ -664,7 +668,7 @@ async def test_max_concurrent_handlers_bounds_in_flight_handlers(
     subscription_id, destination = faker.pystr(), faker.pystr()
     monkeypatch.setattr(stompman.subscription, "_make_subscription_id", mock.Mock(return_value=subscription_id))
 
-    messages = [
+    messages: list[stompman.AnyServerFrame] = [
         build_dataclass(
             MessageFrame,
             headers={
@@ -680,8 +684,9 @@ async def test_max_concurrent_handlers_bounds_in_flight_handlers(
     release = asyncio.Event()
     in_flight = 0
     peak = 0
+    max_concurrent = 2
 
-    async def handler(frame: MessageFrame) -> None:  # noqa: ARG001
+    async def handler(frame: MessageFrame) -> None:
         nonlocal in_flight, peak
         in_flight += 1
         peak = max(peak, in_flight)
@@ -692,7 +697,7 @@ async def test_max_concurrent_handlers_bounds_in_flight_handlers(
 
     connection_class, _ = create_spying_connection(*get_read_frames_with_lifespan(messages))
 
-    async with EnrichedClient(connection_class=connection_class, max_concurrent_handlers=2) as client:
+    async with EnrichedClient(connection_class=connection_class, max_concurrent_handlers=max_concurrent) as client:
         subscription = await client.subscribe(
             destination,
             handler,
@@ -701,9 +706,9 @@ async def test_max_concurrent_handlers_bounds_in_flight_handlers(
         # let the listener queue up to the semaphore limit
         for _ in range(50):
             await asyncio.sleep(0)
-            if peak >= 2:
+            if peak >= max_concurrent:
                 break
-        assert peak == 2, f"expected peak in-flight 2, got {peak}"
+        assert peak == max_concurrent, f"expected peak in-flight {max_concurrent}, got {peak}"
         release.set()
         for _ in range(50):
             await asyncio.sleep(0)
@@ -711,4 +716,4 @@ async def test_max_concurrent_handlers_bounds_in_flight_handlers(
                 break
         await subscription.unsubscribe()
 
-    assert peak == 2
+    assert peak == max_concurrent

--- a/packages/stompman/test_stompman/test_subscription.py
+++ b/packages/stompman/test_stompman/test_subscription.py
@@ -435,18 +435,25 @@ async def test_subscription_skips_ack_nack_after_reconnection(
         client._connection_manager._clear_active_connection_state(build_dataclass(ConnectionLostError))
         await asyncio.sleep(0)
 
-        with caplog.at_level(logging.DEBUG, logger="stompman"):
+        with caplog.at_level(logging.WARNING, logger="stompman"):
             assert stored_message
             await stored_message.ack()
+        ack_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("connection changed since message was received" in r.message.lower() for r in ack_records), (
+            "ack skip must log at WARNING"
+        )
+
+        with caplog.at_level(logging.ERROR, logger="stompman"):
             await stored_message.nack()
+        nack_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert any("connection changed since message was received" in r.message.lower() for r in nack_records), (
+            "nack skip must log at ERROR"
+        )
 
         await subscription.unsubscribe()
 
     assert not [one_frame for one_frame in collected_frames if isinstance(one_frame, AckFrame)]
     assert not [one_frame for one_frame in collected_frames if isinstance(one_frame, NackFrame)]
-    assert any(
-        "connection changed since message was received" in one_message.lower() for one_message in caplog.messages
-    )
 
 
 async def test_subscription_skips_ack_for_message_consumed_after_concurrent_clear(
@@ -512,15 +519,16 @@ async def test_subscription_skips_ack_for_message_consumed_after_concurrent_clea
                 break
         assert received_messages
 
-        with caplog.at_level(logging.DEBUG, logger="stompman"):
+        with caplog.at_level(logging.WARNING, logger="stompman"):
             await received_messages[0].ack()
+        ack_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("connection changed since message was received" in r.message.lower() for r in ack_records), (
+            "ack skip must log at WARNING"
+        )
 
         await subscription.unsubscribe()
 
     assert not [one_frame for one_frame in collected_frames if isinstance(one_frame, AckFrame)]
-    assert any(
-        "connection changed since message was received" in one_message.lower() for one_message in caplog.messages
-    )
 
 
 async def test_auto_ack_handler_unhandled_exception_does_not_kill_listener(

--- a/packages/stompman/test_stompman/test_subscription.py
+++ b/packages/stompman/test_stompman/test_subscription.py
@@ -523,6 +523,53 @@ async def test_subscription_skips_ack_for_message_consumed_after_concurrent_clea
     )
 
 
+async def test_auto_ack_handler_unhandled_exception_does_not_kill_listener(
+    monkeypatch: pytest.MonkeyPatch, faker: faker.Faker, caplog: pytest.LogCaptureFixture
+) -> None:
+    subscription_id, destination, ack_id_a, ack_id_b = faker.pystr(), faker.pystr(), faker.pystr(), faker.pystr()
+    monkeypatch.setattr(stompman.subscription, "_make_subscription_id", mock.Mock(return_value=subscription_id))
+
+    message_a = build_dataclass(
+        MessageFrame,
+        headers={"destination": destination, "message-id": "a", "subscription": subscription_id, "ack": ack_id_a},
+    )
+    message_b = build_dataclass(
+        MessageFrame,
+        headers={"destination": destination, "message-id": "b", "subscription": subscription_id, "ack": ack_id_b},
+    )
+
+    class Boom(BaseException):  # not Exception: NOT in suppressed_exception_classes
+        pass
+
+    handled: list[str] = []
+
+    async def handler(frame: MessageFrame) -> None:
+        handled.append(frame.headers["message-id"])
+        if frame.headers["message-id"] == "a":
+            raise Boom
+
+    connection_class, _collected_frames = create_spying_connection(
+        *get_read_frames_with_lifespan([message_a, message_b])
+    )
+
+    async with EnrichedClient(connection_class=connection_class) as client:
+        with caplog.at_level(logging.ERROR, logger="stompman"):
+            subscription = await client.subscribe(
+                destination,
+                handler,
+                on_suppressed_exception=noop_error_handler,
+                suppressed_exception_classes=(),  # nothing suppressed
+            )
+            for _ in range(20):
+                await asyncio.sleep(0)
+                if len(handled) == 2:
+                    break
+            await subscription.unsubscribe()
+
+    assert handled == ["a", "b"], "second message must be handled after first one crashed"
+    assert any("unhandled exception in message handler" in m.lower() for m in caplog.messages)
+
+
 def test_make_subscription_id() -> None:
     stompman.subscription._make_subscription_id()
 

--- a/packages/stompman/test_stompman/test_subscription.py
+++ b/packages/stompman/test_stompman/test_subscription.py
@@ -648,3 +648,59 @@ async def test_client_exits_when_subscriptions_are_unsubscribed(
         UnsubscribeFrame(headers={"id": first_id}),
         UnsubscribeFrame(headers={"id": second_id}),
     )
+
+
+async def test_max_concurrent_handlers_bounds_in_flight_handlers(
+    monkeypatch: pytest.MonkeyPatch, faker: faker.Faker
+) -> None:
+    subscription_id, destination = faker.pystr(), faker.pystr()
+    monkeypatch.setattr(stompman.subscription, "_make_subscription_id", mock.Mock(return_value=subscription_id))
+
+    messages = [
+        build_dataclass(
+            MessageFrame,
+            headers={
+                "destination": destination,
+                "message-id": str(i),
+                "subscription": subscription_id,
+                "ack": faker.pystr(),
+            },
+        )
+        for i in range(5)
+    ]
+
+    release = asyncio.Event()
+    in_flight = 0
+    peak = 0
+
+    async def handler(frame: MessageFrame) -> None:  # noqa: ARG001
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        try:
+            await release.wait()
+        finally:
+            in_flight -= 1
+
+    connection_class, _ = create_spying_connection(*get_read_frames_with_lifespan(messages))
+
+    async with EnrichedClient(connection_class=connection_class, max_concurrent_handlers=2) as client:
+        subscription = await client.subscribe(
+            destination,
+            handler,
+            on_suppressed_exception=noop_error_handler,
+        )
+        # let the listener queue up to the semaphore limit
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if peak >= 2:
+                break
+        assert peak == 2, f"expected peak in-flight 2, got {peak}"
+        release.set()
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if in_flight == 0:
+                break
+        await subscription.unsubscribe()
+
+    assert peak == 2

--- a/packages/stompman/test_stompman/test_subscription.py
+++ b/packages/stompman/test_stompman/test_subscription.py
@@ -546,7 +546,7 @@ async def test_auto_ack_handler_unhandled_exception_does_not_kill_listener(
         headers={"destination": destination, "message-id": "b", "subscription": subscription_id, "ack": ack_id_b},
     )
 
-    class Boom(BaseException):  # not Exception: NOT in suppressed_exception_classes
+    class BoomError(Exception):  # not in suppressed_exception_classes
         pass
 
     handled: list[str] = []
@@ -556,7 +556,7 @@ async def test_auto_ack_handler_unhandled_exception_does_not_kill_listener(
     async def handler(frame: MessageFrame) -> None:  # noqa: RUF029
         handled.append(frame.headers["message-id"])
         if frame.headers["message-id"] == "a":
-            raise Boom
+            raise BoomError
 
     connection_class, _collected_frames = create_spying_connection(
         *get_read_frames_with_lifespan([message_a, message_b])

--- a/packages/stompman/test_stompman/test_subscription.py
+++ b/packages/stompman/test_stompman/test_subscription.py
@@ -570,6 +570,43 @@ async def test_auto_ack_handler_unhandled_exception_does_not_kill_listener(
     assert any("unhandled exception in message handler" in m.lower() for m in caplog.messages)
 
 
+async def test_manual_ack_handler_unhandled_exception_does_not_kill_listener(
+    monkeypatch: pytest.MonkeyPatch, faker: faker.Faker, caplog: pytest.LogCaptureFixture
+) -> None:
+    subscription_id, destination = faker.pystr(), faker.pystr()
+    monkeypatch.setattr(stompman.subscription, "_make_subscription_id", mock.Mock(return_value=subscription_id))
+
+    message_a = build_dataclass(
+        MessageFrame,
+        headers={"destination": destination, "message-id": "a", "subscription": subscription_id, "ack": faker.pystr()},
+    )
+    message_b = build_dataclass(
+        MessageFrame,
+        headers={"destination": destination, "message-id": "b", "subscription": subscription_id, "ack": faker.pystr()},
+    )
+
+    handled: list[str] = []
+
+    async def handler(frame: stompman.subscription.AckableMessageFrame) -> None:
+        handled.append(frame.headers["message-id"])
+        if frame.headers["message-id"] == "a":
+            raise RuntimeError("boom")
+
+    connection_class, _ = create_spying_connection(*get_read_frames_with_lifespan([message_a, message_b]))
+
+    async with EnrichedClient(connection_class=connection_class) as client:
+        with caplog.at_level(logging.ERROR, logger="stompman"):
+            subscription = await client.subscribe_with_manual_ack(destination, handler)
+            for _ in range(20):
+                await asyncio.sleep(0)
+                if len(handled) == 2:
+                    break
+            await subscription.unsubscribe()
+
+    assert handled == ["a", "b"]
+    assert any("unhandled exception in message handler" in m.lower() for m in caplog.messages)
+
+
 def test_make_subscription_id() -> None:
     stompman.subscription._make_subscription_id()
 


### PR DESCRIPTION
## Summary

In production, faststream-stomp consumers stop processing messages while `broker.ping()` keeps returning `True`. Queue depth grows on the broker (ActiveMQ Artemis), the DLQ also grows, and only a pod restart recovers.

This PR addresses every failure mode that can lead to that state:

- **Listener safety net** — wrap every per-message handler so a single handler crash can no longer cancel the read loop. Previously, an unhandled exception inside a handler would cancel the inner `TaskGroup` and silently kill the listen task.
- **`is_alive` grace fix** — `ActiveConnectionState` now tracks `connected_at`; when `last_read_time is None`, aliveness is bounded by the same `server_heartbeat × factor` threshold instead of returning `True` indefinitely. Closes the indefinite-True window after a reconnect where nothing reads.
- **Listen-task death surfaces in `is_alive`** — `Client.is_alive()` returns `False` once `_listen_task.done()`, so dead listeners can no longer report healthy.
- **Unhandled listen-task exceptions are logged** — `_handle_listen_task_done` now logs every non-cancelled, non-`FailedAllConnectAttemptsError` exception at ERROR with the traceback. Previously these were silently swallowed.
- **`max_concurrent_handlers` knob** — opt-in semaphore (default `None`/unbounded) bounds in-flight handler tasks. When the semaphore is full the read loop pauses, which (combined with the `is_alive` fix above) converts an invisible stuck-state into a detectable one.
- **Visibility for ack/nack drops** — ack-skip-after-reconnect → WARNING; nack-skip-after-reconnect → ERROR. Dropped frames inside `maybe_write_frame` are also logged with severity by frame type (NACK=ERROR, ACK=WARNING, other=INFO) so DLQ growth becomes diagnosable from logs alone.

## Test plan

- [x] `just lint`
- [x] `just check-types`
- [x] `just test-fast` — 244 passed / 1 skipped
- [ ] `just test` — full suite (requires Docker brokers); run before merge

## Notes for reviewers

- Default behavior is preserved: `max_concurrent_handlers` is `None` by default; existing call sites do not need changes.